### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/envtest.md
+++ b/docs/envtest.md
@@ -262,7 +262,7 @@ must poll for the expected state, with a user-configured timeout and polling int
 `envtest` ITs can also exercise controller failures modes by emulating conditions under which your controller will error
 out.
 
-To see a full example of a `envtest` IT, refer to the [Achilles Federation controller test](https://github.snooguts.net/reddit/achilles/blob/f5f453b25216fd25f68c22b453345eb6777efbf0/orchestration-controller-manager/internal/controllers/federation/federation_reconciler_test.go).
+To see a full example of a `envtest` IT, refer to the [achilles-token-controller example test](https://github.com/reddit/achilles-token-controller/blob/b807e6b4f8000830aa2596132d73d466441a5d17/internal/controllers/accesstoken/reconciler_suite_test.go#L40).
 
 ### Running Your Test
 

--- a/docs/envtest.md
+++ b/docs/envtest.md
@@ -87,10 +87,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.snooguts.net/reddit/achilles-sdk/pkg/fsm/metrics"
-	"github.snooguts.net/reddit/achilles-sdk/pkg/logging"
-	libratelimiter "github.snooguts.net/reddit/achilles-sdk/pkg/ratelimiter"
-	"github.snooguts.net/reddit/achilles-sdk/pkg/test"
+	"github.com/reddit/achilles-sdk/pkg/fsm/metrics"
+	"github.com/reddit/achilles-sdk/pkg/logging"
+	libratelimiter "github.com/reddit/achilles-sdk/pkg/ratelimiter"
+	"github.com/reddit/achilles-sdk/pkg/test"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -98,10 +98,10 @@ import (
 	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.snooguts.net/reddit/mycontroller/internal/controllers/mycontroller"
-	"github.snooguts.net/reddit/mycontroller/internal/controlplane"
-	libtest "github.snooguts.net/reddit/mycontroller/internal/test"
-	ctrlscheme "github.snooguts.net/reddit/mycontroller/pkg/scheme"
+	"github.com/reddit/mycontroller/internal/controllers/mycontroller"
+	"github.com/reddit/mycontroller/internal/controlplane"
+	libtest "github.com/reddit/mycontroller/internal/test"
+	ctrlscheme "github.com/reddit/mycontroller/pkg/scheme"
 )
 
 var (

--- a/docs/sdk-apply-objects.md
+++ b/docs/sdk-apply-objects.md
@@ -4,7 +4,7 @@ This document describes conventions and patterns around performing updates to Ku
 
 ## OutputSet
 
-The `achilles-sdk`'s FSM reconciler supplies an [`OutputSet` abstraction](https://github.snooguts.net/reddit/achilles-sdk/blob/340f21a1aa4595651c8627fe754a44082bfab34b/pkg/fsm/types/output.go#L17)
+The `achilles-sdk`'s FSM reconciler supplies an [`OutputSet` abstraction](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a1a988cd05629df5ea4502b5ff2ea/pkg/fsm/types/output.go#L17)
 that should satisfy _most_ use resource update use cases.
 
 The following illustrates the typical pattern:
@@ -206,7 +206,7 @@ This enables Kubernetes-native garbage collection, whereby all managed resources
 gets deleted. This default behavior makes sense in _most_ controller use cases.
 
 If your controller is intentionally managing owner references, you must disable this feature by using the `io.WithoutOwnerRefs()` 
-([link](https://github.snooguts.net/reddit/achilles-sdk/blob/dea76bcf6143aebce5ba0763f99c9f282b5b3415/pkg/io/options.go#L44))
+([link](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a1a988cd05629df5ea4502b5ff2ea/pkg/io/options.go#L45))
 apply option.
 
 ### Mutation Based Updates
@@ -300,8 +300,8 @@ by using the resource lock.
 
 ## References
 
-1. The full list of apply options lives under [`/pkg/io/options.go`](https://github.snooguts.net/reddit/achilles-sdk/blob/0a9d9df29d5201b0f3d689108547c3a97d819d82/pkg/io/options.go)
-2. The client abstraction lives under [`/pkg/io/applicator.go`](https://github.snooguts.net/reddit/achilles-sdk/blob/0a9d9df29d5201b0f3d689108547c3a97d819d82/pkg/io/applicator.go)
+1. The full list of apply options lives under [`/pkg/io/options.go`](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a1a988cd05629df5ea4502b5ff2ea/pkg/io/options.go)
+2. The client abstraction lives under [`/pkg/io/applicator.go`](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a1a988cd05629df5ea4502b5ff2ea/pkg/io/applicator.go)
 
 [^1]: Read more about [Go serialization here](https://pkg.go.dev/encoding/json#Marshal)
 [^2]: We could theoretically implement or use a custom Go JSON marshaller that can output `key: null` to signal deletion of fields.

--- a/docs/sdk-apply-objects.md
+++ b/docs/sdk-apply-objects.md
@@ -112,7 +112,7 @@ all `spec` and `status` fields are types that allow omission when serializing fr
 This means that actors can send updates while _omitting_ fields that they do not own, thus preventing collisions
 with other owners.
 
-Following these two assumptions, we can optimistically apply all object updates without utilizing Kubernetes' [resource version](https://github.snooguts.net/reddit/reddit-helm-charts#versioning)
+Following these two assumptions, we can optimistically apply all object updates without utilizing Kubernetes' resource version
 because there is no risk that any actor's update will conflict with or overwrite that of a different actor's.
 
 We also update all objects using [JSON merge patch semantics](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment),

--- a/docs/sdk-apply-objects.md
+++ b/docs/sdk-apply-objects.md
@@ -177,7 +177,7 @@ This guarantees that your controller will not overwrite data managed by other co
 To use the resource lock, do the following:
 
 ```golang
-import "github.snooguts.net/reddit/achilles-sdk/pkg/io"
+import "github.com/reddit/achilles-sdk/pkg/io"
 
 out.Apply(obj, io.WithOptimisticLock())
 ```
@@ -191,7 +191,7 @@ To perform a full object update, supply to `AsUpdate()` apply option like so:
 
 
 ```golang
-import "github.snooguts.net/reddit/achilles-sdk/pkg/io"
+import "github.com/reddit/achilles-sdk/pkg/io"
 
 out.Apply(obj, io.AsUpdate())
 ```

--- a/docs/sdk-claim-claimed-reconcilers.md
+++ b/docs/sdk-claim-claimed-reconcilers.md
@@ -29,7 +29,7 @@ It's desirable for the `claim` object to be namespace scoped for one of the foll
    1. Note (April 17th, 2024) that the `achilles-sdk` hasn't implemented this decoupling pattern yet because no concrete use cases have required it.
 
 The `achilles-sdk` creates two independent reconcilers for the `claim` and `claimed` objects.
-The `claim` reconciler is entirely managed by the sdk and does not require any work on the user's part ([ref](https://github.snooguts.net/reddit/achilles-sdk/blob/main/pkg/fsm/internal/reconciler_claim.go#L43)).
+The `claim` reconciler is entirely managed by the sdk and does not require any work on the user's part ([ref](https://github.com/reddit/achilles-sdk/blob/main/pkg/fsm/internal/reconciler_claim.go#L43)).
 The `claim` reconciler is responsible for creating the `claimed` object if it does not exist and cascading a delete call when the `claim` object is deleted.
 The developer is responsible for implementing the `claimed` reconciler using the exposed [FSM semantics]({{< ref "dev/sdk/sdk-fsm-reconciler" >}}).
 As an example take a look at the [ASGRotator Controller](https://github.snooguts.net/reddit/achilles/blob/master/orchestration-controller-manager/internal/controllers/cloud-resources/asgrotator/controller.go).

--- a/docs/sdk-claim-claimed-reconcilers.md
+++ b/docs/sdk-claim-claimed-reconcilers.md
@@ -27,6 +27,6 @@ It's desirable for the `claim` object to be namespace scoped for one of the foll
    1. Note (April 17th, 2024) that the `achilles-sdk` hasn't implemented this decoupling pattern yet because no concrete use cases have required it.
 
 The `achilles-sdk` creates two independent reconcilers for the `claim` and `claimed` objects.
-The `claim` reconciler is entirely managed by the sdk and does not require any work on the user's part ([ref](https://github.com/reddit/achilles-sdk/blob/main/pkg/fsm/internal/reconciler_claim.go#L43)).
+The `claim` reconciler is entirely managed by the sdk and does not require any work on the user's part ([ref](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a1a988cd05629df5ea4502b5ff2ea/pkg/fsm/internal/reconciler_claim.go#L45)).
 The `claim` reconciler is responsible for creating the `claimed` object if it does not exist and cascading a delete call when the `claim` object is deleted.
 The developer is responsible for implementing the `claimed` reconciler using the exposed [FSM semantics]({{< ref "dev/sdk/sdk-fsm-reconciler" >}}).

--- a/docs/sdk-claim-claimed-reconcilers.md
+++ b/docs/sdk-claim-claimed-reconcilers.md
@@ -6,10 +6,8 @@ This guide walks you through the claim/claimed reconciler pattern available in t
 
 The `achilles-sdk` in addition to the base [FSM reconciler]({{< ref "dev/sdk/sdk-fsm-reconciler" >}}) also provides a claim/claimed reconciler pattern.
 This pattern uses the same FSM semantics from a developer perspective. This pattern is built around two types of resources:
-1. **Claim**: A claim resource is created by an end user or client claiming access to a resource. An example of this type of resource is [`RedisClusterClaim`](https://github.snooguts.net/reddit/achilles-redis-controllers/blob/main/api/storage/v1alpha1/redisclusterclaim_type.go)
-  which claims access to a `RedisCluster` instance.
-2. **Claimed**: A claimed resource captures the actual instance of given object. An example of this type of resource is [`RedisCluster`](https://github.snooguts.net/reddit/achilles-redis-controllers/blob/main/api/storage/v1alpha1/rediscluster_type.go)
-  which captures the actual resources running in AWS.
+1. **Claim**: A claim resource is created by an end user or client claiming access to a resource.
+2. **Claimed**: A claimed resource captures the actual instance of given object.
 
 **The `claim` object is namespaced whereas the `claimed` object is cluster-scoped**.
 
@@ -32,4 +30,3 @@ The `achilles-sdk` creates two independent reconcilers for the `claim` and `clai
 The `claim` reconciler is entirely managed by the sdk and does not require any work on the user's part ([ref](https://github.com/reddit/achilles-sdk/blob/main/pkg/fsm/internal/reconciler_claim.go#L43)).
 The `claim` reconciler is responsible for creating the `claimed` object if it does not exist and cascading a delete call when the `claim` object is deleted.
 The developer is responsible for implementing the `claimed` reconciler using the exposed [FSM semantics]({{< ref "dev/sdk/sdk-fsm-reconciler" >}}).
-As an example take a look at the [ASGRotator Controller](https://github.snooguts.net/reddit/achilles/blob/master/orchestration-controller-manager/internal/controllers/cloud-resources/asgrotator/controller.go).

--- a/docs/sdk-finalizers.md
+++ b/docs/sdk-finalizers.md
@@ -35,5 +35,5 @@ var finalizerState = &state{
 ### Finalizer for claim/claimed reconciler
 
 For the claim/claimed reconciler, the sdk automatically adds a finalizer to the `claim` object.
-This is to ensure the sdk is able to delete the `claimed` object when the `claim` object is deleted ([ref](https://github.snooguts.net/reddit/achilles-sdk/blob/main/pkg/fsm/internal/reconciler_claim.go)).
+This is to ensure the sdk is able to delete the `claimed` object when the `claim` object is deleted ([ref](https://github.com/reddit/achilles-sdk/blob/main/pkg/fsm/internal/reconciler_claim.go)).
 The behaviour of the finalizer on the `claimed` object is controlled by the `finalizerState` provided to the controller as explained above

--- a/docs/sdk-finalizers.md
+++ b/docs/sdk-finalizers.md
@@ -35,5 +35,5 @@ var finalizerState = &state{
 ### Finalizer for claim/claimed reconciler
 
 For the claim/claimed reconciler, the sdk automatically adds a finalizer to the `claim` object.
-This is to ensure the sdk is able to delete the `claimed` object when the `claim` object is deleted ([ref](https://github.com/reddit/achilles-sdk/blob/main/pkg/fsm/internal/reconciler_claim.go)).
+This is to ensure the sdk is able to delete the `claimed` object when the `claim` object is deleted ([ref](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a1a988cd05629df5ea4502b5ff2ea/pkg/fsm/internal/reconciler_claim.go#L24)).
 The behaviour of the finalizer on the `claimed` object is controlled by the `finalizerState` provided to the controller as explained above

--- a/docs/sdk-fsm-reconciler.md
+++ b/docs/sdk-fsm-reconciler.md
@@ -107,7 +107,7 @@ to ensure the execution of logic that triggers when an object is deleted. Object
 terminating state, but not get deleted from Kubernetes state, until the finalizer is removed.
 
 The FSM provides a way to add a separate FSM triggered upon deletion of
-objects, [see this example](https://github.snooguts.net/reddit/achilles/blob/36c3aa3bde5a2590f5d914918a8cefdf1ef953a7/lib/fsm/test/test_fsm_reconciler.go#L39)
+objects, [see this example](https://github.com/reddit/achilles-token-controller/blob/b807e6b4f8000830aa2596132d73d466441a5d17/internal/controllers/accesstoken/reconciler.go#L162-L166)
 . The FSM automatically manages the attachment and removal of the finalizer. The finalizer will only be removed if the
 finalizer FSM terminates successfully.
 
@@ -128,5 +128,5 @@ the [`.Watches` method](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a
 
 ## Example FSM Controllers
 
-See [this simple example](https://github.snooguts.net/reddit/achilles/blob/1499fc7d792c9d717572bea58e85ccb597245bb3/lib/fsm/test/test_fsm_reconciler.go)
+See [this simple example](https://github.com/reddit/achilles-token-controller)
 for reference on how to implement an FSM controller.

--- a/docs/sdk-fsm-reconciler.md
+++ b/docs/sdk-fsm-reconciler.md
@@ -54,7 +54,7 @@ to controller restarts and any runtime errors.
 
 Every state in the FSM maps to a [status condition](https://maelvls.dev/kubernetes-conditions/) on the parent object,
 which is defined by the
-developer [for each state](https://github.snooguts.net/reddit/achilles/blob/c0ddc4dadb6a7613552598da773bd77b80b15c0c/lib/fsm/types/transitions.go#L52)
+developer [for each state](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a1a988cd05629df5ea4502b5ff2ea/pkg/fsm/types/core.go#L31)
 . If the state completes successfully, the status condition's `Status` field will be set to true. Otherwise, in the case
 of a
 requeue result or error, the status field will be set to false.
@@ -70,7 +70,7 @@ Each state defines the next state to transition to the current state completes s
 based on logical conditions, allowing the expression of branching paths.
 
 Each state
-defines [a result type](https://github.snooguts.net/reddit/achilles/blob/c0ddc4dadb6a7613552598da773bd77b80b15c0c/lib/fsm/types/transitions.go#L118-L165)
+defines [a result type](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a1a988cd05629df5ea4502b5ff2ea/pkg/fsm/types/results.go#L21)
 .
 Broadly speaking, there are three types of results:
 
@@ -92,7 +92,7 @@ An error result is used when an external condition is not expected to be false.
 
 The majority of controllers involve creating and updating Kubernetes objects, whether they are CRDs or native resources.
 The FSM framework provides
-an [output object set abstraction](https://github.snooguts.net/reddit/achilles/blob/c0ddc4dadb6a7613552598da773bd77b80b15c0c/lib/fsm/types/transitions.go#L41)
+an [output object set abstraction](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a1a988cd05629df5ea4502b5ff2ea/pkg/fsm/types/output.go#L17)
 for ensuring outputs. It provides the following functionality:
 
 - output objects are tracked via the parent object's status
@@ -116,14 +116,14 @@ finalizer FSM terminates successfully.
 The FSM exposes the same trigger conditions as controller-runtime.
 
 When building a new controller,
-use `.Manages` ([source](https://github.snooguts.net/reddit/achilles/blob/e8f58f6d9a66ab799da21ae9eb1cdc373e56e2d2/lib/fsm/controller.go#L76))
+use `.Manages` ([source](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a1a988cd05629df5ea4502b5ff2ea/pkg/fsm/builder.go#L93))
 to specify the type of object that is being managed by the controller. Each controller can only manage a single object
 type.
 
 The FSM automatically wires up triggers for all [managed resources](##Writing and Updating Managed Resources).
 
 Additional trigger conditions can be wired up for arbitrary events via
-the [`.Watches` method](https://github.snooguts.net/reddit/achilles/blob/e8f58f6d9a66ab799da21ae9eb1cdc373e56e2d2/lib/fsm/controller.go#L109)
+the [`.Watches` method](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a1a988cd05629df5ea4502b5ff2ea/pkg/fsm/builder.go#L134)
 .
 
 ## Example FSM Controllers

--- a/docs/sdk-metrics.md
+++ b/docs/sdk-metrics.md
@@ -62,9 +62,9 @@ The "type" label indicates the type of triggering object:
 1. **"self"** triggers happen by nature of controller-runtime's reconciler model, where any event on the reconciled object 
 triggers a reconciliation.
 2. **"relative"** triggers occur through events on related objects. Related object triggers are wired up
-using the `.Watches()` [builder method](https://github.snooguts.net/reddit/achilles-sdk/blob/bd2f3522d9e38b513f3a0f206f9bb9b0532c8b50/pkg/fsm/controller.go#L136).
+using the `.Watches()` [builder method](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a1a988cd05629df5ea4502b5ff2ea/pkg/fsm/builder.go#L134).
 3. **"child"** triggers occur through events on managed child objects (objects whose `meta.ownerRef` refers to the reconciled object). Child triggers
-are wired up using the `.Manages()` [builder method](https://github.snooguts.net/reddit/achilles-sdk/blob/bd2f3522d9e38b513f3a0f206f9bb9b0532c8b50/pkg/fsm/controller.go#L96)
+are wired up using the `.Manages()` [builder method](https://github.com/reddit/achilles-sdk/blob/4fe0f620d71a1a988cd05629df5ea4502b5ff2ea/pkg/fsm/builder.go#L93)
 
 ```c
 achilles_trigger{

--- a/docs/sdk-metrics.md
+++ b/docs/sdk-metrics.md
@@ -9,20 +9,10 @@ The Achilles SDK
 integrates [controller-runtime metrics](https://github.com/kubernetes-sigs/controller-runtime/blob/1ed345090869edc4bd94fe220386cb7fa5df745f/pkg/internal/controller/metrics/metrics.go).
 Controller-runtime metrics provide foundational metrics for understanding the performance and health of your controller.
 
-These metrics can be viewed in
-the ["Controller Runtime" Grafana dashboard](https://grafana.kubernetes.ue1.snooguts.net/d/Md5CPB44k/controller-runtime?orgId=1&refresh=30s&var-cluster=orch-1&var-prometheus=monitoring%2Finfrared-system&var-controller=All&var-webhook=All&from=1721981744523&to=1722003344523).
-
 ## SDK Metrics
 
 The Achilles SDK provides additional metrics that leverage SDK conventions and structures to provide more detailed
 insights into the health and performance of your controller.
-
-These metrics are displayed in the following Grafana dashboards:
-
-1. [Achilles Reconciler Metrics](https://grafana.kubernetes.ue1.snooguts.net/d/p_-RmaUVk/achilles-reconciler-metrics?orgId=1&from=1721960667563&to=1722003867564)
-   1. Provides a high level overview of your controller and its custom resources
-2. [Achilles Reconciler Detailed Metrics](https://grafana.kubernetes.ue1.snooguts.net/d/0gaENrwVk/achilles-reconciler-detailed-metrics?orgId=1&from=1721982323248&to=1722003923249)
-   1. Provides a detailed overview of particular reconcile loops of your controller.
 
 ### **`achilles_resource_readiness`**
 
@@ -118,5 +108,3 @@ achilles_state_duration_seconds_bucket{
   le="0.99",                            // the percentile of the histogram distribution
 } 183                                   // the duration in milliseconds
 ```
-
-The average durations are graphed over time in the [Achilles Detailed Reconciler Metrics dashboard](https://grafana.kubernetes.ue1.snooguts.net/d/0gaENrwVk/achilles-reconciler-detailed-metrics?orgId=1&from=1721983467755&to=1722005067755).

--- a/pkg/io/applicator.go
+++ b/pkg/io/applicator.go
@@ -55,7 +55,7 @@ type RequestOptions struct {
 // An APIPatchingApplicator applies changes to an object by either creating or
 // patching it in a Kubernetes API server.
 // For a detailed discussion of the reasoning behind these semantics, see this doc,
-// https://pages.github.snooguts.net/reddit/achilles-docs/dev/sdk/sdk-apply-objects/.
+// https://github.com/reddit/achilles-sdk/blob/main/docs/sdk-apply-objects.md.
 type APIApplicator struct {
 	client client.Client
 }


### PR DESCRIPTION
## 💸 TL;DR
Updates links that pointed to non-public resources

## 📜 Details
After attending yesterday's (awesome) KubeCon session about this library, I started combing through the docs but kept hitting broken or private links.  I've therefore attempted to update those links in this PR to the best location I could determine.

Please double-check my changes here (especially in the `sdk-fsm-reconciler.md` file) since I haven't actually used this library yet and don't want to mislead other developers by pointing to the wrong places! 😅 

## 🧪 Testing Steps / Validation
I manually clicked the updated links to ensure they loaded?

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
