### PR TITLE
Add requestId to logs

### DIFF
--- a/pkg/fsm/internal/reconciler.go
+++ b/pkg/fsm/internal/reconciler.go
@@ -91,7 +91,8 @@ func (r *fsmReconciler[T, Obj]) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	log := r.log.With("request", req, "requestId", requestId)
 	log.Debug("entering reconcile")
-	defer log.Debug("exiting reconcile")
+	startedAt := time.Now()
+	defer func() { log.Debug("finished reconcile in %s", time.Since(startedAt)) }()
 
 	// record metrics
 	defer func() {

--- a/pkg/fsm/internal/reconciler.go
+++ b/pkg/fsm/internal/reconciler.go
@@ -88,7 +88,7 @@ func (r *fsmReconciler[T, Obj]) Reconcile(ctx context.Context, req ctrl.Request)
 	log := r.log.With("request", req, "requestId", requestId)
 	log.Debug("entering reconcile")
 	startedAt := time.Now()
-	defer func() { log.Debug("finished reconcile in %s", time.Since(startedAt)) }()
+	defer func() { log.Debugf("finished reconcile in %s", time.Since(startedAt)) }()
 
 	// record metrics
 	defer func() {

--- a/pkg/fsm/internal/reconciler.go
+++ b/pkg/fsm/internal/reconciler.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
@@ -86,9 +85,6 @@ func NewFSMReconciler[T any, Obj apitypes.FSMResource[T]](
 
 func (r *fsmReconciler[T, Obj]) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	requestId := ctrlcontroller.ReconcileIDFromContext(ctx)
-	if requestId == "" {
-		requestId = uuid.NewUUID()
-	}
 	log := r.log.With("request", req, "requestId", requestId)
 	log.Debug("entering reconcile")
 	startedAt := time.Now()

--- a/pkg/fsm/internal/reconciler.go
+++ b/pkg/fsm/internal/reconciler.go
@@ -14,8 +14,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/reddit/achilles-sdk-api/api"
 	apitypes "github.com/reddit/achilles-sdk-api/pkg/types"
@@ -83,7 +85,11 @@ func NewFSMReconciler[T any, Obj apitypes.FSMResource[T]](
 }
 
 func (r *fsmReconciler[T, Obj]) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.log.With("request", req)
+	requestId := ctrlcontroller.ReconcileIDFromContext(ctx)
+	if requestId == "" {
+		requestId = uuid.NewUUID()
+	}
+	log := r.log.With("request", req, "requestId", requestId)
 	log.Debug("entering reconcile")
 	defer log.Debug("exiting reconcile")
 

--- a/pkg/fsm/internal/reconciler_claim.go
+++ b/pkg/fsm/internal/reconciler_claim.go
@@ -11,7 +11,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
@@ -47,9 +46,6 @@ type BeforeDelete[
 
 func (r *ClaimReconciler[T, Claimed, U, Claim]) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	requestId := ctrlcontroller.ReconcileIDFromContext(ctx)
-	if requestId == "" {
-		requestId = uuid.NewUUID()
-	}
 	log := r.Log.With("request", req, "requestId", requestId)
 	log.Debug("entering reconcile")
 	startedAt := time.Now()

--- a/pkg/fsm/internal/reconciler_claim.go
+++ b/pkg/fsm/internal/reconciler_claim.go
@@ -10,8 +10,10 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/reddit/achilles-sdk-api/api"
 	apitypes "github.com/reddit/achilles-sdk-api/pkg/types"
@@ -43,7 +45,11 @@ type BeforeDelete[
 ] func(Claim, Claimed) error
 
 func (r *ClaimReconciler[T, Claimed, U, Claim]) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.With("request", req)
+	requestId := ctrlcontroller.ReconcileIDFromContext(ctx)
+	if requestId == "" {
+		requestId = uuid.NewUUID()
+	}
+	log := r.Log.With("request", req, "requestId", requestId)
 	log.Debug("entering reconcile")
 	defer log.Debug("exiting reconcile")
 

--- a/pkg/fsm/internal/reconciler_claim.go
+++ b/pkg/fsm/internal/reconciler_claim.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -51,7 +52,8 @@ func (r *ClaimReconciler[T, Claimed, U, Claim]) Reconcile(ctx context.Context, r
 	}
 	log := r.Log.With("request", req, "requestId", requestId)
 	log.Debug("entering reconcile")
-	defer log.Debug("exiting reconcile")
+	startedAt := time.Now()
+	defer func() { log.Debug("finished reconcile in %s", time.Since(startedAt)) }()
 
 	claim := Claim(new(U))
 	if err := r.Client.Get(ctx, req.NamespacedName, claim); k8serrors.IsNotFound(err) {

--- a/pkg/fsm/internal/reconciler_claim.go
+++ b/pkg/fsm/internal/reconciler_claim.go
@@ -49,7 +49,7 @@ func (r *ClaimReconciler[T, Claimed, U, Claim]) Reconcile(ctx context.Context, r
 	log := r.Log.With("request", req, "requestId", requestId)
 	log.Debug("entering reconcile")
 	startedAt := time.Now()
-	defer func() { log.Debug("finished reconcile in %s", time.Since(startedAt)) }()
+	defer func() { log.Debugf("finished reconcile in %s", time.Since(startedAt)) }()
 
 	claim := Claim(new(U))
 	if err := r.Client.Get(ctx, req.NamespacedName, claim); k8serrors.IsNotFound(err) {


### PR DESCRIPTION
## 💸 TL;DR
Adds requestId to logs so that lines for a single reconciliation can be easily filtered.

```
# before
logger.go:146: 2025-02-28T15:55:58.461-0500 DEBUG   TestClaim       entering reconcile      {"request": "/test-claim"}
logger.go:146: 2025-02-28T15:55:58.461-0500 DEBUG   TestClaim       exiting reconcile in 23.791µs  {"request": "/test-claim"}

# after
logger.go:146: 2025-02-28T15:55:58.461-0500 DEBUG   TestClaim       entering reconcile      {"request": "/test-claim", "requestId": "32d46c84-deb9-4aa9-ad0e-32f714699f9a"}
logger.go:146: 2025-02-28T15:55:58.461-0500 DEBUG   TestClaim       exiting reconcile in 23.791µs  {"request": "/test-claim", "requestId": "32d46c84-deb9-4aa9-ad0e-32f714699f9a"}
```