### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           # needed for running `tar -xJv` for installing shellcheck
           apt-get update
-          apt-get install xz-utils
+          apt-get install -y xz-utils
           
           make generate
           git status


### PR DESCRIPTION
CI failed on [this commit](https://github.com/reddit/achilles-sdk/pull/30/commits) because we were waiting for user input

## 💸 TL;DR
Automatically run `apt-get install` with `-y` flag to avoid requiring user input

## 🧪 Testing Steps / Validation
ci here

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
