### PR TITLE
Fix makefile force flag (`-B`) behavior with go-get-tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ENVTEST_CMD := $(ENVTEST)
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
-@[ -f $(1) ] || { \
+@{ \
 set -e ;\
 echo "Downloading $(2)" ;\
 GOBIN=$(PROJECT_DIR)/bin go install -modfile=tools/go.mod $(2) ;\


### PR DESCRIPTION
## Summary
`make` assumes that if the file exists, then not to rerun the target.

if you want to override this behavior, you provide `-B`. for example, `make generate` should generate files with whatever version of binaries you happen to have in `/bin`, but `make generate -B` should re-download the binaries to ensure your output matches CI. This PR fixes this behavior

### Testing

Note after this PR that `make generate` downloads the binaries _only if they don't already exist_ and `make generate -B` will refresh them to match `tools/go.mod` no matter what (as expected)