### PR TITLE
[OutputSet] add `DeleteAll` method

### DIFF
--- a/pkg/fsm/types/output.go
+++ b/pkg/fsm/types/output.go
@@ -77,6 +77,13 @@ func (s *OutputSet) Delete(o client.Object) {
 	s.deleted.Insert(o)
 }
 
+// DeleteAll is equivalent to calling Delete(obj) for all supplied objects.
+func (s *OutputSet) DeleteAll(objs ...client.Object) {
+	for _, o := range objs {
+		s.Delete(o)
+	}
+}
+
 // DeleteByRef is the same as Delete, but takes an api.TypedObjectRef instead of an object.
 func (s *OutputSet) DeleteByRef(typedObjRef api.TypedObjectRef) {
 	apiVersion, kind := typedObjRef.GroupVersionKind().ToAPIVersionAndKind()

--- a/pkg/fsm/types/output_test.go
+++ b/pkg/fsm/types/output_test.go
@@ -24,6 +24,8 @@ func Test_OutputSet(t *testing.T) {
 	o2 := cm("cm2", "ns")
 	o2applyOpts := []io.ApplyOption{io.AsUpdate(), io.WithOptimisticLock()}
 	o3 := cm("cm3", "ns")
+	o4 := cm("cm4", "ns")
+	o5 := cm("cm4", "ns")
 
 	// case 1: add object without apply option
 	outputSet.Apply(o1)
@@ -60,6 +62,18 @@ func Test_OutputSet(t *testing.T) {
 	}
 	if outputSet.applied.Has(o3) {
 		t.Errorf("unexpected existence of o3 in applied set")
+	}
+
+	// case 4: exercise ApplyAll and DeleteAll
+	outputSet.ApplyAll(o4, o5)
+	expectedApplied := sets.NewObjectSet(scheme, o1, o2, o4, o5)
+	if !outputSet.applied.Equal(expectedApplied) {
+		t.Errorf("unexpected applied set after applying o4 and o5")
+	}
+	outputSet.DeleteAll(o4, o5)
+	expectedDeleted = sets.NewObjectSet(scheme, o3, o4, o5)
+	if !outputSet.deleted.Equal(expectedDeleted) {
+		t.Errorf("unexpected deleted set after deleting o4 and o5")
 	}
 }
 


### PR DESCRIPTION
Adds a `outputSet.DeleteAll` convenience method.

The tests need to be rewritten as a standard table-style test, I'll pick that up in a later PR time permitting.