### PR TITLE
[handler] Fix rate limiting behavior

### DIFF
--- a/pkg/fsm/handler/observed_event_handler.go
+++ b/pkg/fsm/handler/observed_event_handler.go
@@ -96,7 +96,7 @@ func (h *ObservedEventHandler) observedQueue(
 
 func (q *observedQueue) Add(item reconcile.Request) {
 	q.observeEvent(item)
-	q.TypedRateLimitingInterface.AddRateLimited(item)
+	q.TypedRateLimitingInterface.Add(item)
 }
 
 // logs an event trigger


### PR DESCRIPTION
## Overview

This bug was introduced in [this PR](https://github.com/reddit/achilles-sdk/commit/89f7ce81bf138537f44a16d078f575c85759de3d#diff-8a6aa68a68e984c6abb797b1c0397e645d7382dcd9d4d390e060f070974c0ca0L97-L101)—we accidentally updated the observed event handler to rate limit _all events_, whereas controller-runtime's behavior is to only rate limit error and requeue (without specified delays) results.

## Implications

Controllers subject to this bug, if rate limits are actively delaying new work from being enqueued, will see unexpected delays from when a trigger event fires in the cluster to when it is processed by the controller. Normally, triggers other than errors and requeues (without specified delays) should be enqueued immediately.

Worst case this behavior results in downstream user/system impact where they experience undue latency from a spec change to when it's instantiated.

This is the exact behavior I saw [described here](https://github.snooguts.net/reddit/achilles/pull/1548), which I never found the root cause of. With this one line change, the test succeeds, giving me confidence that this is the root cause of unexpected delays in processing.