### PR TITLE
Expose additional required leader election configs

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -76,7 +76,7 @@ type Options struct {
 	// The renew deadline for this leader election controller.
 	// Must be set to ensure the resource lock has an appropriate client timeout.
 	// If set too low, a single slow response from the API server can result
-	// in losing leadership.
+	// in losing leadership. Defaults to 10 seconds.
 	// Note: This must be set lower than the LeaderElectionLeaseDuration.
 	LeaderElectionRenewDeadline time.Duration
 


### PR DESCRIPTION
## 💸 TL;DR
Exposes CLI knobs for `LeaderElectionID`, `LeaderElectionNamespace`, and `RenewDeadline` which are all mandatory configurations that must be specified when enabling leader election.

Also optionally expose `LeaseDuration` for configuration since this setting must be increased if `RenewDeadline` is bumped.

See inline comments for details on these settings.

## 🧪 Testing Steps / Validation
I used these settings in our internal OCM on EKS and was able to see this error go away:
```
fatal: building manager: constructing manager: LeaderElectionID must be configured
```

OCM pods were able to progress with no further CLBO.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
