### PR TITLE
Bump go to 1.24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.23"
+          - "1.24"
 
     container:
       image: golang:${{ matrix.go-version }}

--- a/pkg/encoding/json/encode_test.go
+++ b/pkg/encoding/json/encode_test.go
@@ -7,6 +7,7 @@ package json
 import (
 	"bytes"
 	"encoding"
+	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -1192,11 +1193,11 @@ func TestMarshalerError(t *testing.T) {
 		want string
 	}{
 		{
-			&MarshalerError{st, fmt.Errorf(errText), ""},
+			&MarshalerError{st, errors.New(errText), ""},
 			"json: error calling MarshalJSON for type " + st.String() + ": " + errText,
 		},
 		{
-			&MarshalerError{st, fmt.Errorf(errText), "TestMarshalerError"},
+			&MarshalerError{st, errors.New(errText), "TestMarshalerError"},
 			"json: error calling TestMarshalerError for type " + st.String() + ": " + errText,
 		},
 	}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/clamoriniere/crd-to-markdown v0.0.3


### PR DESCRIPTION
## 💸 TL;DR
Bumps the CI version of Go to version 1.24. This fixes the [CI failure](https://github.com/reddit/achilles-sdk/actions/runs/15145033677/job/42578706595) on main resulting from a [dependabot change](https://github.com/reddit/achilles-sdk/commit/32d5d9d26735ca42a53c3aa60922be1fe4f997d9) that upgraded client-go and reliance on Go 1.24.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
