### PR TITLE
Will k8s event dedupe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/pkg/fsm/events/events.go
+++ b/pkg/fsm/events/events.go
@@ -1,6 +1,10 @@
 package events
 
 import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,29 +24,41 @@ type EventRecorder struct {
 	metrics  *metrics.Metrics
 
 	controllerName string
+
+	client client.Client
+	scheme *runtime.Scheme
 }
 
 // NewEventRecorder creates a new EventRecorder for the given controller and manager.
 // Metrics is optional and can be nil. If provided, it will be used to emit metrics for each event.
 func NewEventRecorder(controllerName string, manager ctrl.Manager, metrics *metrics.Metrics) *EventRecorder {
-	return &EventRecorder{recorder: manager.GetEventRecorderFor(controllerName), metrics: metrics, controllerName: controllerName}
+	return &EventRecorder{
+		recorder:       manager.GetEventRecorderFor(controllerName),
+		metrics:        metrics,
+		controllerName: controllerName,
+		client:         manager.GetClient(),
+		scheme:         manager.GetScheme(),
+	}
 }
 
-// RecordReady records a ready event for the given object.
-// message is optional and defaults to "Object is ready".
+// RecordReady records a ready event for the given object
+// It will only record the event the first time it is called (i.e. deduplication is always enabled for the Ready event)
 func (e *EventRecorder) RecordReady(obj client.Object, message string) {
 	if message == "" {
 		message = "Object is ready"
 	}
-	e.recorder.Event(obj, eventTypeNormal, eventReadyReason, message)
-
-	if e.metrics != nil {
-		e.metrics.RecordEvent(obj.GetObjectKind().GroupVersionKind(), obj.GetName(), obj.GetNamespace(), eventTypeNormal, eventReadyReason, e.controllerName)
-	}
+	e.RecordEvent(obj, eventReadyReason, message, true)
 }
 
 // RecordWarning records a warning event for the given object.
-func (e *EventRecorder) RecordWarning(obj client.Object, reason string, message string) {
+// If deduplicationEnabled is true, it will only record the event the first time it is called.
+func (e *EventRecorder) RecordWarning(obj client.Object, reason string, message string, deduplicationEnabled bool) {
+	if deduplicationEnabled {
+		if e.isDuplicateEventForObject(obj, eventTypeWarning, reason, message) {
+			return // Skip recording duplicate event
+		}
+	}
+
 	e.recorder.Event(obj, eventTypeWarning, reason, message)
 
 	if e.metrics != nil {
@@ -51,10 +67,39 @@ func (e *EventRecorder) RecordWarning(obj client.Object, reason string, message 
 }
 
 // RecordEvent records a normal event for the given object.
-func (e *EventRecorder) RecordEvent(obj client.Object, reason string, message string) {
+// If deduplicationEnabled is true, it will only record the event the first time it is called.
+func (e *EventRecorder) RecordEvent(obj client.Object, reason string, message string, deduplicationEnabled bool) {
+	if deduplicationEnabled {
+		if e.isDuplicateEventForObject(obj, eventTypeNormal, reason, message) {
+			return // Skip recording duplicate event
+		}
+	}
+
 	e.recorder.Event(obj, eventTypeNormal, reason, message)
 
 	if e.metrics != nil {
 		e.metrics.RecordEvent(obj.GetObjectKind().GroupVersionKind(), obj.GetName(), obj.GetNamespace(), eventTypeNormal, reason, e.controllerName)
 	}
+}
+
+// isDuplicateEventForObject checks if an event with the same type, reason, and message already exists for the object.
+func (e *EventRecorder) isDuplicateEventForObject(obj client.Object, eventType, reason, message string) bool {
+	// Get existing events using UID field selector
+	eventList := &corev1.EventList{}
+	fieldSelector := client.MatchingFields{
+		"involvedObject.uid": string(obj.GetUID()),
+	}
+	err := e.client.List(context.Background(), eventList, fieldSelector)
+	if err != nil {
+		// If we can't retrieve existing events, err on the side of caution and allow the event
+		return false
+	}
+
+	// Check if any existing event matches the type, reason, and message
+	for _, event := range eventList.Items {
+		if event.Type == eventType && event.Reason == reason && event.Message == message {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/fsm/events/events_test.go
+++ b/pkg/fsm/events/events_test.go
@@ -1,0 +1,503 @@
+package events
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// MockEventRecorder is a mock implementation of record.EventRecorder
+type MockEventRecorder struct {
+	mock.Mock
+}
+
+func (m *MockEventRecorder) Event(object runtime.Object, eventType, reason, message string) {
+	m.Called(object, eventType, reason, message)
+}
+
+func (m *MockEventRecorder) Eventf(object runtime.Object, eventType, reason, messageFmt string, args ...interface{}) {
+	m.Called(object, eventType, reason, messageFmt, args)
+}
+
+func (m *MockEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventType, reason, messageFmt string, args ...interface{}) {
+	m.Called(object, annotations, eventType, reason, messageFmt, args)
+}
+
+func TestEventRecorder_RecordEvent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+
+	tests := []struct {
+		name                 string
+		deduplicationEnabled bool
+		existingEvents       []corev1.Event
+		newEventType         string
+		newEventReason       string
+		newEventMessage      string
+		expectedEventCount   int
+		expectEventRecorded  bool
+	}{
+		{
+			name:                 "deduplication disabled - should always record",
+			deduplicationEnabled: false,
+			existingEvents: []corev1.Event{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Event"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-event-1",
+						Namespace: "default",
+					},
+					Type:           "Normal",
+					Reason:         "TestReason",
+					Message:        "Test message",
+					FirstTimestamp: metav1.Now(),
+					InvolvedObject: corev1.ObjectReference{
+						Name:       "test-configmap",
+						Namespace:  "default",
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+						UID:        "test-configmap-uid",
+					},
+				},
+			},
+			newEventType:        "Normal",
+			newEventReason:      "TestReason",
+			newEventMessage:     "Test message",
+			expectedEventCount:  1,
+			expectEventRecorded: true,
+		},
+		{
+			name:                 "deduplication enabled - duplicate event - our event should NOT be recorded",
+			deduplicationEnabled: true,
+			existingEvents: []corev1.Event{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Event"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-event-1",
+						Namespace: "default",
+					},
+					Type:           "Normal",
+					Reason:         "TestReason",
+					Message:        "Test message",
+					FirstTimestamp: metav1.Now(),
+					InvolvedObject: corev1.ObjectReference{
+						Name:       "test-configmap",
+						Namespace:  "default",
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+						UID:        "test-configmap-uid",
+					},
+				},
+			},
+			newEventType:        "Normal",
+			newEventReason:      "TestReason",
+			newEventMessage:     "Test message",
+			expectedEventCount:  0,
+			expectEventRecorded: false,
+		},
+		{
+			name:                 "deduplication enabled - different reason - our event should be recorded",
+			deduplicationEnabled: true,
+			existingEvents: []corev1.Event{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Event"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-event-1",
+						Namespace: "default",
+					},
+					Type:           "Normal",
+					Reason:         "TestReason",
+					Message:        "Test message",
+					FirstTimestamp: metav1.Now(),
+					InvolvedObject: corev1.ObjectReference{
+						Name:       "test-configmap",
+						Namespace:  "default",
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+						UID:        "test-configmap-uid",
+					},
+				},
+			},
+			newEventType:        "Normal",
+			newEventReason:      "DifferentReason",
+			newEventMessage:     "Test message",
+			expectedEventCount:  1,
+			expectEventRecorded: true,
+		},
+		{
+			name:                 "deduplication enabled - different message - our event should be recorded",
+			deduplicationEnabled: true,
+			existingEvents: []corev1.Event{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Event"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-event-1",
+						Namespace: "default",
+					},
+					Type:           "Normal",
+					Reason:         "TestReason",
+					Message:        "Test message",
+					FirstTimestamp: metav1.Now(),
+					InvolvedObject: corev1.ObjectReference{
+						Name:       "test-configmap",
+						Namespace:  "default",
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+						UID:        "test-configmap-uid",
+					},
+				},
+			},
+			newEventType:        "Normal",
+			newEventReason:      "TestReason",
+			newEventMessage:     "Different message",
+			expectedEventCount:  1,
+			expectEventRecorded: true,
+		},
+		{
+			name:                 "deduplication enabled - no existing events - our event should be recorded",
+			deduplicationEnabled: true,
+			existingEvents:       []corev1.Event{},
+			newEventType:         "Normal",
+			newEventReason:       "TestReason",
+			newEventMessage:      "Test message",
+			expectedEventCount:   1,
+			expectEventRecorded:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fake client with existing events and field index for UID
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithIndex(&corev1.Event{}, "involvedObject.uid", func(obj client.Object) []string {
+					event := obj.(*corev1.Event)
+					return []string{string(event.InvolvedObject.UID)}
+				}).
+				Build()
+
+			// Add existing events to the fake client
+			for _, event := range tt.existingEvents {
+				err := fakeClient.Create(context.Background(), &event)
+				assert.NoError(t, err)
+			}
+
+			// Create mock event recorder
+			mockRecorder := &MockEventRecorder{}
+
+			// Create EventRecorder
+			eventRecorder := &EventRecorder{
+				recorder:       mockRecorder,
+				metrics:        nil, // No metrics for this test
+				controllerName: "test-controller",
+				client:         fakeClient,
+				scheme:         scheme,
+			}
+
+			// Create test object
+			testObj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "default",
+					UID:       "test-configmap-uid",
+				},
+			}
+			// Set the GVK explicitly
+			testObj.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+
+			// Set up mock expectations
+			if tt.expectEventRecorded {
+				// RecordEventWithDeduplication always records "Normal" events
+				mockRecorder.On("Event", testObj, "Normal", tt.newEventReason, tt.newEventMessage).Once()
+			}
+
+			// Record the event
+			eventRecorder.RecordEvent(testObj, tt.newEventReason, tt.newEventMessage, tt.deduplicationEnabled)
+
+			// Verify mock expectations
+			mockRecorder.AssertExpectations(t)
+		})
+	}
+}
+
+func TestEventRecorder_RecordReady(t *testing.T) {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+
+	tests := []struct {
+		name                string
+		existingEvents      []corev1.Event
+		message             string
+		expectEventRecorded bool
+	}{
+		{
+			name: "duplicate ready event - our ready event should NOT be recorded",
+			existingEvents: []corev1.Event{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Event"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-event-1",
+						Namespace: "default",
+					},
+					Type:           "Normal",
+					Reason:         "Ready",
+					Message:        "Object is ready",
+					FirstTimestamp: metav1.Now(),
+					InvolvedObject: corev1.ObjectReference{
+						Name:       "test-configmap",
+						Namespace:  "default",
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+						UID:        "test-configmap-uid",
+					},
+				},
+			},
+			message:             "",
+			expectEventRecorded: false,
+		},
+		{
+			name: "different ready message - our ready event should be recorded",
+			existingEvents: []corev1.Event{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Event"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-event-1",
+						Namespace: "default",
+					},
+					Type:           "Normal",
+					Reason:         "Ready",
+					Message:        "Object is ready",
+					FirstTimestamp: metav1.Now(),
+					InvolvedObject: corev1.ObjectReference{
+						Name:       "test-configmap",
+						Namespace:  "default",
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+						UID:        "test-configmap-uid",
+					},
+				},
+			},
+			message:             "Custom ready message",
+			expectEventRecorded: true,
+		},
+		{
+			name:                "no existing events - our ready event should be recorded",
+			existingEvents:      []corev1.Event{},
+			message:             "",
+			expectEventRecorded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fake client with existing events and field index for UID
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithIndex(&corev1.Event{}, "involvedObject.uid", func(obj client.Object) []string {
+					event := obj.(*corev1.Event)
+					return []string{string(event.InvolvedObject.UID)}
+				}).
+				Build()
+
+			// Add existing events to the fake client
+			for _, event := range tt.existingEvents {
+				err := fakeClient.Create(context.Background(), &event)
+				assert.NoError(t, err)
+			}
+
+			// Create mock event recorder
+			mockRecorder := &MockEventRecorder{}
+
+			// Create EventRecorder
+			eventRecorder := &EventRecorder{
+				recorder:       mockRecorder,
+				metrics:        nil,
+				controllerName: "test-controller",
+				client:         fakeClient,
+				scheme:         scheme,
+			}
+
+			// Create test object
+			testObj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "default",
+					UID:       "test-configmap-uid",
+				},
+			}
+			// Set the GVK explicitly
+			testObj.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+
+			// Set up mock expectations
+			if tt.expectEventRecorded {
+				expectedMessage := tt.message
+				if expectedMessage == "" {
+					expectedMessage = "Object is ready"
+				}
+				mockRecorder.On("Event", testObj, "Normal", "Ready", expectedMessage).Once()
+			}
+
+			// Record the ready event
+			eventRecorder.RecordReady(testObj, tt.message)
+
+			// Verify mock expectations
+			mockRecorder.AssertExpectations(t)
+		})
+	}
+}
+
+func TestEventRecorder_RecordWarning(t *testing.T) {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+
+	tests := []struct {
+		name                 string
+		deduplicationEnabled bool
+		existingEvents       []corev1.Event
+		reason               string
+		message              string
+		expectEventRecorded  bool
+	}{
+		{
+			name:                 "deduplication enabled - duplicate warning event - our warning event should NOT be recorded",
+			deduplicationEnabled: true,
+			existingEvents: []corev1.Event{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Event"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-event-1",
+						Namespace: "default",
+					},
+					Type:           "Warning",
+					Reason:         "TestWarning",
+					Message:        "Test warning message",
+					FirstTimestamp: metav1.Now(),
+					InvolvedObject: corev1.ObjectReference{
+						Name:       "test-configmap",
+						Namespace:  "default",
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+						UID:        "test-configmap-uid",
+					},
+				},
+			},
+			reason:              "TestWarning",
+			message:             "Test warning message",
+			expectEventRecorded: false,
+		},
+		{
+			name:                 "deduplication enabled - different warning reason - our warning event should be recorded",
+			deduplicationEnabled: true,
+			existingEvents: []corev1.Event{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Event"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-event-1",
+						Namespace: "default",
+					},
+					Type:           "Warning",
+					Reason:         "TestWarning",
+					Message:        "Test warning message",
+					FirstTimestamp: metav1.Now(),
+					InvolvedObject: corev1.ObjectReference{
+						Name:       "test-configmap",
+						Namespace:  "default",
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+						UID:        "test-configmap-uid",
+					},
+				},
+			},
+			reason:              "DifferentWarning",
+			message:             "Test warning message",
+			expectEventRecorded: true,
+		},
+		{
+			name:                 "deduplication disabled - duplicate warning event - our warning event should be recorded",
+			deduplicationEnabled: false,
+			existingEvents: []corev1.Event{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Event"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-event-1",
+						Namespace: "default",
+					},
+					Type:           "Warning",
+					Reason:         "TestWarning",
+					Message:        "Test warning message",
+					FirstTimestamp: metav1.Now(),
+					InvolvedObject: corev1.ObjectReference{
+						Name:       "test-configmap",
+						Namespace:  "default",
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+						UID:        "test-configmap-uid",
+					},
+				},
+			},
+			reason:              "TestWarning",
+			message:             "Test warning message",
+			expectEventRecorded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fake client with existing events and field index for UID
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithIndex(&corev1.Event{}, "involvedObject.uid", func(obj client.Object) []string {
+					event := obj.(*corev1.Event)
+					return []string{string(event.InvolvedObject.UID)}
+				}).
+				Build()
+
+			// Add existing events to the fake client
+			for _, event := range tt.existingEvents {
+				err := fakeClient.Create(context.Background(), &event)
+				assert.NoError(t, err)
+			}
+
+			// Create mock event recorder
+			mockRecorder := &MockEventRecorder{}
+
+			// Create EventRecorder
+			eventRecorder := &EventRecorder{
+				recorder:       mockRecorder,
+				metrics:        nil,
+				controllerName: "test-controller",
+				client:         fakeClient,
+				scheme:         scheme,
+			}
+
+			// Create test object
+			testObj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "default",
+					UID:       "test-configmap-uid",
+				},
+			}
+			// Set the GVK explicitly
+			testObj.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+
+			// Set up mock expectations
+			if tt.expectEventRecorded {
+				mockRecorder.On("Event", testObj, "Warning", tt.reason, tt.message).Once()
+			}
+
+			// Record the warning event
+			eventRecorder.RecordWarning(testObj, tt.reason, tt.message, tt.deduplicationEnabled)
+
+			// Verify mock expectations
+			mockRecorder.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
## 💸 TL;DR
This PR adds optional dedupe logic to the events package. If enabled, It looks at the existing events on the Resource, and if an identical event exists, it does not record the event.

## 🧪 Testing Steps / Validation
I've just tested using my brain and the unit tests - I'd love advice for how I can test this against a real cluster.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
