### PR TITLE
[metrics] fix concurrency panic in processing duration

### DIFF
--- a/pkg/fsm/metrics/internal/processing_duration.go
+++ b/pkg/fsm/metrics/internal/processing_duration.go
@@ -140,7 +140,6 @@ func (p *ProcessingStartTimes) SetRangeFailed(name string, namespace string, obs
 		Generation: observedGeneration,
 	}
 
-	var items []requestStartTime
 	p.startTimes.DescendLessOrEqual(key, func(item requestStartTime) bool {
 		if item.Name != key.Name || item.Namespace != key.Namespace {
 			// end of range for (name, namespace)
@@ -152,14 +151,9 @@ func (p *ProcessingStartTimes) SetRangeFailed(name string, namespace string, obs
 			return false
 		}
 
-		// accumulate items to delete to avoid mutating tree while iterating,
-		// because this btree implementation doesn't support writes while iterating
-		items = append(items, item)
-		return true
-	})
-
-	for _, item := range items {
 		item.Failed = true
 		p.startTimes.ReplaceOrInsert(item)
-	}
+
+		return true
+	})
 }

--- a/pkg/fsm/metrics/internal/processing_duration.go
+++ b/pkg/fsm/metrics/internal/processing_duration.go
@@ -140,6 +140,7 @@ func (p *ProcessingStartTimes) SetRangeFailed(name string, namespace string, obs
 		Generation: observedGeneration,
 	}
 
+	var items []requestStartTime
 	p.startTimes.DescendLessOrEqual(key, func(item requestStartTime) bool {
 		if item.Name != key.Name || item.Namespace != key.Namespace {
 			// end of range for (name, namespace)
@@ -151,9 +152,14 @@ func (p *ProcessingStartTimes) SetRangeFailed(name string, namespace string, obs
 			return false
 		}
 
-		item.Failed = true
-		p.startTimes.ReplaceOrInsert(item)
-
+		// accumulate items to delete to avoid mutating tree while iterating,
+		// because this btree implementation doesn't support writes while iterating
+		items = append(items, item)
 		return true
 	})
+
+	for _, item := range items {
+		item.Failed = true
+		p.startTimes.ReplaceOrInsert(item)
+	}
 }

--- a/pkg/fsm/metrics/internal/processing_duration_test.go
+++ b/pkg/fsm/metrics/internal/processing_duration_test.go
@@ -557,6 +557,13 @@ func Test_ProcessingStartTimes_Concurrency(t *testing.T) {
 	const numWriters = 10
 	const numOps = 1000
 
+	// Pre-populate
+	for i := 0; i < 1000; i++ {
+		name := fmt.Sprintf("name-%d", i%5)
+		ns := fmt.Sprintf("ns-%d", i%5)
+		p.Set(name, ns, int64(i), time.Now())
+	}
+
 	// Readers
 	for i := 0; i < numReaders; i++ {
 		wg.Add(1)
@@ -584,11 +591,11 @@ func Test_ProcessingStartTimes_Concurrency(t *testing.T) {
 				op := j % 3
 				switch op {
 				case 0:
-					p.Set(name, ns, int64(j%10), time.Now())
+					p.Set(name, ns, int64(j), time.Now())
 				case 1:
-					p.DeleteRange(name, ns, int64(j%10))
+					p.DeleteRange(name, ns, int64(j))
 				case 2:
-					p.SetRangeFailed(name, ns, int64(j%10))
+					p.SetRangeFailed(name, ns, int64(j))
 				}
 			}
 		}(i)

--- a/pkg/fsm/metrics/internal/processing_duration_test.go
+++ b/pkg/fsm/metrics/internal/processing_duration_test.go
@@ -557,7 +557,7 @@ func Test_ProcessingStartTimes_Concurrency(t *testing.T) {
 	const numWriters = 10
 	const numOps = 1000
 
-	// Pre-populate
+	// Pre-populate with name-{0..4}, ns-{0..4}, generation {0..999}
 	for i := 0; i < 1000; i++ {
 		name := fmt.Sprintf("name-%d", i%5)
 		ns := fmt.Sprintf("ns-%d", i%5)
@@ -595,6 +595,7 @@ func Test_ProcessingStartTimes_Concurrency(t *testing.T) {
 				case 1:
 					p.DeleteRange(name, ns, int64(j))
 				case 2:
+					// exercise that SetRangeFailed can run concurrently with other operations
 					p.SetRangeFailed(name, ns, int64(j))
 				}
 			}

--- a/pkg/fsm/metrics/internal/processing_duration_test.go
+++ b/pkg/fsm/metrics/internal/processing_duration_test.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -543,4 +545,55 @@ func Test_ProcessingStartTimes_SetRangeFailed(t *testing.T) {
 			assert.Equal(t, tc.expectedTree, got)
 		})
 	}
+}
+
+func Test_ProcessingStartTimes_Concurrency(t *testing.T) {
+	p := NewProcessingStartTimes()
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	// Number of concurrent readers and writers
+	const numReaders = 10
+	const numWriters = 10
+	const numOps = 1000
+
+	// Readers
+	for i := 0; i < numReaders; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			<-start
+			for j := 0; j < numOps; j++ {
+				// Read varied keys
+				name := fmt.Sprintf("name-%d", j%5)
+				ns := fmt.Sprintf("ns-%d", j%5)
+				p.GetRange(name, ns, int64(j%10), j%2 == 0)
+			}
+		}(i)
+	}
+
+	// Writers
+	for i := 0; i < numWriters; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			<-start
+			for j := 0; j < numOps; j++ {
+				name := fmt.Sprintf("name-%d", j%5)
+				ns := fmt.Sprintf("ns-%d", j%5)
+				op := j % 3
+				switch op {
+				case 0:
+					p.Set(name, ns, int64(j%10), time.Now())
+				case 1:
+					p.DeleteRange(name, ns, int64(j%10))
+				case 2:
+					p.SetRangeFailed(name, ns, int64(j%10))
+				}
+			}
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
 }


### PR DESCRIPTION
The processing duration metric implementation uses `google/btree`, which is [not safe to mutate during iteration](https://github.com/google/btree/issues/18#issuecomment-283457598).

The fix is simple, accumulate the items during iteration and mutate after.

I confirmed the root cause with a reproduction in a unit test (it's non-deterministic, you have to run it a few times), where I saw the exact same index out of bounds panic:

```shell
panic: runtime error: index out of range [47] with length 31

goroutine 21 [running]:
github.com/google/btree.(*node[...]).iterate(0x104a953a0, 0x0, {{{0x140004ac230?, 0x4}, {0x140004ac218, 0x6}, 0x23c, {0x0, 0x0, 0x0}, ...}, ...}, ...)
	/Users/harvey.xia/.gvm/pkgsets/go1.24/global/pkg/mod/github.com/google/btree@v1.1.3/btree_generic.go:541 +0x998
github.com/google/btree.(*node[...]).iterate(0x104a953a0, 0x14000295ce8, {{{0x140004ac230?, 0x4}, {0x140004ac218, 0x6}, 0x23c, {0x0, 0x0, 0x0}, ...}, ...}, ...)
	/Users/harvey.xia/.gvm/pkgsets/go1.24/global/pkg/mod/github.com/google/btree@v1.1.3/btree_generic.go:560 +0x940
github.com/google/btree.(*BTreeG[...]).DescendLessOrEqual(0x0?, {{0x140004ac230?, 0x4}, {0x140004ac218, 0x6}, 0x23c, {0x0, 0x0, 0x0}, 0x0}, ...)
	/Users/harvey.xia/.gvm/pkgsets/go1.24/global/pkg/mod/github.com/google/btree@v1.1.3/btree_generic.go:797 +0x120
github.com/reddit/achilles-sdk/pkg/fsm/metrics/internal.(*ProcessingStartTimes).SetRangeFailed(0x1400007c620, {0x140004ac218, 0x6}, {0x140004ac230, 0x4}, 0x23c)
	/Users/harvey.xia/Code/achilles-sdk/pkg/fsm/metrics/internal/processing_duration.go:143 +0x134
github.com/reddit/achilles-sdk/pkg/fsm/metrics/internal.Test_ProcessingStartTimes_Concurrency.func2(0x0?)
	/Users/harvey.xia/Code/achilles-sdk/pkg/fsm/metrics/internal/processing_duration_test.go:599 +0x164
created by github.com/reddit/achilles-sdk/pkg/fsm/metrics/internal.Test_ProcessingStartTimes_Concurrency in goroutine 7
	/Users/harvey.xia/Code/achilles-sdk/pkg/fsm/metrics/internal/processing_duration_test.go:585 +0x320
```