### PR TITLE
Fix controller-runtime v0.23 Apply ambiguity

### DIFF
--- a/pkg/fsm/builder.go
+++ b/pkg/fsm/builder.go
@@ -276,7 +276,7 @@ func (b *Builder[T, Obj]) Build() SetupFunc {
 			managedGVKs[i] = managedType.gvk
 		}
 
-		r := b.Reconciler(log, scheme, c, metrics)
+		r := b.Reconciler(log, scheme, c.Client, metrics)
 
 		builder := ctrl.NewControllerManagedBy(mgr).
 			WithOptions(controller.Options{

--- a/pkg/fsm/internal/reconciler.go
+++ b/pkg/fsm/internal/reconciler.go
@@ -148,7 +148,7 @@ func (r *fsmReconciler[T, Obj]) Reconcile(ctx context.Context, req ctrl.Request)
 	// having been processed (if, for instance, an external actor deletes the object after `r.reconcile(ctx, req)`
 	// and before this condition.
 	if meta.WasDeleted(obj) && r.finalizerState != nil && result.IsDone() {
-		if err := meta.RemoveFinalizer(ctx, r.client, obj, finalizerKey); err != nil {
+		if err := meta.RemoveFinalizer(ctx, r.client.Client, obj, finalizerKey); err != nil {
 			return ctrl.Result{}, fmt.Errorf("removing FSM finalizer: %w", err)
 		}
 	}
@@ -210,7 +210,7 @@ func (r *fsmReconciler[T, Obj]) reconcile(
 	// ensure finalizer if finalizer states exist, do not add if the resource has already been deleted
 	// as no new finalizers can be added to the resource
 	if r.finalizerState != nil && !slices.Contains(obj.GetFinalizers(), finalizerKey) && !meta.WasDeleted(obj) {
-		if err := meta.AddFinalizer(ctx, r.client, obj, finalizerKey); err != nil {
+		if err := meta.AddFinalizer(ctx, r.client.Client, obj, finalizerKey); err != nil {
 			return nil, nil, types.ErrorResult(fmt.Errorf("adding FSM finalizer: %w", err))
 		}
 	}

--- a/pkg/fsm/io/outputs.go
+++ b/pkg/fsm/io/outputs.go
@@ -149,7 +149,7 @@ func ensureOutputs[T any, Obj apitypes.FSMResource[T]](
 			// NOTE: add the default WithControllerRef last so it's not invoked if WithoutOwnerRefs is set
 			applyOpts := append(output.ApplyOpts, io.WithControllerRef(obj, scheme))
 
-			if err := c.Apply(ctx, res, applyOpts...); err != nil {
+			if err := c.Applicator.Apply(ctx, res, applyOpts...); err != nil {
 				return fmt.Errorf("ensuring %s %s: %w", res.GetObjectKind().GroupVersionKind(), res.GetName(), err)
 			}
 		}

--- a/pkg/fsm/types/transitions.go
+++ b/pkg/fsm/types/transitions.go
@@ -266,7 +266,9 @@ func DeleteChildrenForeground[T ResourceManagerObject](
 		parent T,
 		out *OutputSet,
 	) (*State[T], Result) {
-		children, err := readManagedResources(ctx, c, scheme, parent)
+		// c embeds both client.Client and Applicator; pass the explicit client.Client
+		// to avoid method ambiguity in newer controller-runtime versions.
+		children, err := readManagedResources(ctx, c.Client, scheme, parent)
 		if err != nil {
 			return nil, ErrorResultf("reading managed resources: %w", err)
 		}


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->

  Closes # <!-- none yet -->

  ## 💸 TL;DR

  This PR fixes controller-runtime v0.23+ compatibility in Achilles SDK by resolving ClientApplicator method ambiguity around Apply.
  ClientApplicator embeds both client.Client and Applicator; newer controller-runtime adds Apply(...) on client.Client, causing ambiguous selector errors and interface mismatch when *ClientApplicator is passed as client.Client.
  Fix is minimal: pass .Client where client.Client is required, and call .Applicator.Apply(...) where Achilles apply semantics are intended.

  ## 📜 Details

  Design Doc (!-- N/A --)

  Jira (!-- N/A --)

  Compatibility issue observed:

  - Build failure on stacks using newer controller-runtime/k8s deps:
      - *io.ClientApplicator does not implement client.Client (ambiguous selector ... Apply)

  Changes made:

  - pkg/fsm/types/transitions.go
      - Pass c.Client to functions expecting client.Client.
  - pkg/fsm/io/outputs.go
      - Use c.Applicator.Apply(...) for apply operations.
  - pkg/fsm/internal/reconciler.go
      - Pass r.client.Client to finalizer helpers expecting client.Client.
  - pkg/fsm/internal/reconciler_claim.go
      - Pass r.Client.Client to finalizer helpers.
      - Use r.Client.Applicator.Apply(...) where apply behavior is intended.
  - pkg/fsm/builder.go
      - Pass c.Client into Reconciler(...) where signature expects client.Client.


  ## 🧪 Testing Steps / Validation

  1. Reproduced compile failure before patch with a consumer using controller-runtime v0.23.x.
  2. Applied this patch set and re-ran consumer tests/build:
      - make test passed in consuming operator.
      - compile checks passed for affected packages.
  3. Verified changes are limited to client/applicator dispatch and type compatibility paths.

  ## ✅ Checks

  - [x] CI tests (if present) are passing
  - [x] Adheres to code style for repo
  - [ ] Contributor License Agreement (CLA) completed if not a Reddit employee