### PR TITLE
Fix race in Reconcile where ApplyStatus is called on a deleted object

### DIFF
--- a/pkg/fsm/internal/reconciler.go
+++ b/pkg/fsm/internal/reconciler.go
@@ -137,6 +137,9 @@ func (r *fsmReconciler[T, Obj]) Reconcile(ctx context.Context, req ctrl.Request)
 		// NOTE: status must be updated upon termination of FSM, otherwise steady state won't be reached because
 		// later states that overwrite status conditions of earlier states will trigger reconcile events
 		if err := r.client.ApplyStatus(ctx, obj); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return ctrl.Result{}, nil
+			}
 			return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
 		}
 	}

--- a/pkg/io/applicator.go
+++ b/pkg/io/applicator.go
@@ -183,7 +183,7 @@ func (a *APIApplicator) ApplyStatus(ctx context.Context, o client.Object, opts .
 
 	err := a.client.Get(ctx, types.NamespacedName{Name: m.GetName(), Namespace: m.GetNamespace()}, current)
 	if kerrors.IsNotFound(err) {
-		return errors.New("object does not exist, cannot update its status")
+		return fmt.Errorf("object does not exist, cannot update its status: %w", err)
 	} else if err != nil {
 		return fmt.Errorf("cannot get object: %w", err)
 	}


### PR DESCRIPTION
## 💸 TL;DR
Wrap the k8s NotFound error in ApplyStatus instead of discarding it, and ignore NotFound errors from ApplyStatus in the FSM reconciler since the object no longer exists.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
