### PR TITLE
Fix MergeAPIExtensionsJSON panic on nil Raw bytes

### DIFF
--- a/pkg/json/merge.go
+++ b/pkg/json/merge.go
@@ -15,14 +15,14 @@ func MergeAPIExtensionsJSON(a, b *apiextensionsv1.JSON) (*apiextensionsv1.JSON, 
 	}
 
 	aMap := map[string]interface{}{}
-	if a != nil {
+	if a != nil && len(a.Raw) > 0 {
 		if err := json.Unmarshal(a.Raw, &aMap); err != nil {
 			return nil, fmt.Errorf("unmarshalling first JSON variable: %w", err)
 		}
 	}
 
 	var bMap map[string]interface{}
-	if b != nil {
+	if b != nil && len(b.Raw) > 0 {
 		if err := json.Unmarshal(b.Raw, &bMap); err != nil {
 			return nil, fmt.Errorf("unmarshalling second JSON variable: %w", err)
 		}

--- a/pkg/json/merge_test.go
+++ b/pkg/json/merge_test.go
@@ -54,6 +54,38 @@ func TestMergeMaps(t *testing.T) {
 				Raw: nil,
 			},
 		},
+		{
+			name: "handle non-nil struct with nil Raw (first arg)",
+			a:    &apiextensionsv1.JSON{},
+			b:    nil,
+			expected: &apiextensionsv1.JSON{
+				Raw: []byte(`{}`),
+			},
+		},
+		{
+			name: "handle non-nil struct with nil Raw (second arg)",
+			a:    nil,
+			b:    &apiextensionsv1.JSON{},
+			expected: &apiextensionsv1.JSON{
+				Raw: []byte(`{}`),
+			},
+		},
+		{
+			name: "handle both non-nil structs with nil Raw",
+			a:    &apiextensionsv1.JSON{},
+			b:    &apiextensionsv1.JSON{},
+			expected: &apiextensionsv1.JSON{
+				Raw: []byte(`{}`),
+			},
+		},
+		{
+			name: "handle non-nil struct with empty Raw bytes",
+			a:    &apiextensionsv1.JSON{Raw: []byte{}},
+			b:    &apiextensionsv1.JSON{Raw: []byte{}},
+			expected: &apiextensionsv1.JSON{
+				Raw: []byte(`{}`),
+			},
+		},
 	}
 
 	for _, tc := range stringStringCases {


### PR DESCRIPTION
## 💸 TL;DR
When MergeAPIExtensionsJSON is called with (nil, nil), it returns &apiextensionsv1.JSON{} with Raw: nil. If the result is then passed back into MergeAPIExtensionsJSON (as happens when callers merge in a loop over multiple inputs), the function attempts to json.Unmarshal nil bytes, causing "unexpected end of JSON input".

Add len(Raw) > 0 guards before both json.Unmarshal calls so that non-nil structs with nil or empty Raw are treated the same as nil pointers. The nil+nil early return is preserved to avoid changing the serialized form of existing callers' outputs.

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->
Unit tests.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
