### PR TITLE
Add explicit Apply method to ClientApplicator

### DIFF
--- a/pkg/io/applicator.go
+++ b/pkg/io/applicator.go
@@ -24,6 +24,15 @@ type ClientApplicator struct {
 	Applicator
 }
 
+var _ Applicator = (*ClientApplicator)(nil)
+
+// Apply delegates to the embedded Applicator, resolving the ambiguity between
+// client.Client.Apply (server-side apply, added in controller-runtime v0.22)
+// and Applicator.Apply (patch-based apply with io.ApplyOption).
+func (ca *ClientApplicator) Apply(ctx context.Context, obj client.Object, opts ...ApplyOption) error {
+	return ca.Applicator.Apply(ctx, obj, opts...)
+}
+
 // An Applicator applies changes to an object.
 type Applicator interface {
 	Apply(context.Context, client.Object, ...ApplyOption) error


### PR DESCRIPTION
When consumers use a newer controller-runtime than the SDK, the promoted method set on ClientApplicator breaks. This will also be a problem if/when the SDK itself upgrades. 

**Note:** The SDK itself is not yet on controller-runtime v0.22, making this a preemptive fix. That said, the change is minimal and removes complexity that any consumer on v0.22+ would otherwise have to work around independently. It also means one (minor) fewer thing to address if/when this is upgraded to v0.22+

This is probably worth discussing if this is worth adding now vs later (v0.22+)

Closes #   https://github.com/reddit/achilles-sdk/issues/114

## 💸 TL;DR

controller-runtime v0.22 added `Apply` to `client.Client`. Since `ClientApplicator` embeds both `client.Client` and `Applicator` (which also has `Apply`), Go's method promotion becomes ambiguous for consumers on v0.22+. This adds an explicit `Apply` method that delegates to `Applicator.Apply`, resolving the ambiguity with zero behavioral change.

## 📜 Details

**Background:**
- PR #108 fixed internal SDK call sites affected by this ambiguity but did not address the `ClientApplicator` struct's public API.
- PR #113 (server-side apply option) is orthogonal and can coexist with this change.
- This fix is backwards compatible: on controller-runtime v0.21 (current), promotion still works the same way. The explicit method simply makes the delegation unambiguous regardless of controller-runtime version.

**What changed:**
- Added `func (ca *ClientApplicator) Apply(...)` that delegates to `ca.Applicator.Apply(...)`
- Added `var _ Applicator = (*ClientApplicator)(nil)` compile-time check

**Why now:**
Downstream consumers that depend on achilles-sdk but use controller-runtime v0.22+ are currently broken by this ambiguity. This will also be required when achilles-sdk itself upgrades to v0.22.

## 🧪 Testing Steps / Validation

- `go build ./...` passes across the entire SDK
- Compile-time interface satisfaction check (`var _ Applicator = (*ClientApplicator)(nil)`) serves as a regression guard
- Existing tests in `pkg/io/applicator_test.go` exercise `applicator.Apply(...)` and compile cleanly with the new explicit method
- Zero behavioral change - the explicit method delegates identically to what promotion previously resolved

## ✅ Checks
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee - am Reddit employee