### PR TITLE
transparently requeue `Conflict` errors when using `io.WithOptimisticLock()`

### DIFF
--- a/docs/sdk-apply-objects.md
+++ b/docs/sdk-apply-objects.md
@@ -172,7 +172,9 @@ which consists of:
 
 Usage of the resource lock (i.e. sending the update request with `metadata.resourceVersion` populated) ensures that
 the Kubernetes server will reject the update if it's operating on a version of the object that is out of date.
-This guarantees that your controller will not overwrite data managed by other controllers.
+This guarantees that your controller will not overwrite data managed by other controllers. The SDK transparently
+handles these rejections by requeueing the reconciliation with backoff, which gives your controller the opportunity 
+to read the latest version of the object and retry the update with non-stale data.
 
 To use the resource lock, do the following:
 

--- a/docs/sdk-fsm-reconciler.md
+++ b/docs/sdk-fsm-reconciler.md
@@ -78,7 +78,7 @@ Broadly speaking, there are three types of results:
    terminal state, simply complete
 2. **requeue**—instructs the reconciler to trigger again after a user-specified amount of time. This is used in cases
    where
-   a controller is waiting for an external condition to be fulfilled.
+   a controller is waiting for an external condition to be fulfilled. The SDK will also requeue when applying outputs returns a retryable Conflict error.
 3. **error**—the reconciler logs an error message and will retrigger, the delay of which is subject to exponential
    backoff
 

--- a/pkg/fsm/internal/reconciler.go
+++ b/pkg/fsm/internal/reconciler.go
@@ -290,6 +290,15 @@ func (r *fsmReconciler[T, Obj]) reconcile(
 		}
 
 		if err := r.applyOutputs(ctx, log, obj, out); err != nil {
+			// if the error is a conflict, requeue with backoff instead of erroring
+			if k8serrors.IsConflict(err) {
+				condition.Status = corev1.ConditionFalse
+				condition.Reason = "ApplyOutputsConflict"
+				condition.Message = fmt.Sprintf("Conflict when applying outputs: %v", err)
+				conditions.SetConditions(condition)
+				return obj, conditions, types.RequeueResultWithBackoff(fmt.Sprintf("conflict when applying outputs: %v", err))
+			}
+
 			// Mark the state's condition as failed since outputs couldn't be applied
 			if !condition.IsEmpty() {
 				condition.Status = corev1.ConditionFalse

--- a/pkg/fsm/internal/test/core/controller_test.go
+++ b/pkg/fsm/internal/test/core/controller_test.go
@@ -475,6 +475,53 @@ var _ = Describe("Controller", Ordered, func() {
 		}).Should(Succeed())
 	})
 
+	It("should requeue with backoff on conflict when applying outputs with optimistic lock", func() {
+		// Pre-create the conflict target ConfigMap
+		conflictTarget := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "conflict-target",
+				Namespace: "default",
+			},
+			Data: map[string]string{"original": "data"},
+		}
+		Expect(c.Create(ctx, conflictTarget)).To(Succeed())
+
+		// Trigger the conflict path via annotation
+		claim := newTestClaim()
+		_, err := controllerutil.CreateOrPatch(ctx, c, claim, func() error {
+			if claim.Annotations == nil {
+				claim.Annotations = map[string]string{}
+			}
+			claim.Annotations["result-type"] = "conflict-on-apply"
+			return nil
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify that conflict was detected, Reason is set, and Ready = false
+		Eventually(func(g Gomega) {
+			actualClaim := &testv1alpha1.TestClaim{}
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(claim), actualClaim)).To(Succeed())
+			actual := actualClaim.GetCondition("custom-status-condition")
+			g.Expect(actual.Status).To(Equal(corev1.ConditionFalse))
+			g.Expect(string(actual.Reason)).To(Equal("ApplyOutputsConflict"))
+			g.Expect(status.ResourceReady(actualClaim)).To(BeFalse())
+		}).Should(Succeed())
+
+		// Remove annotation to allow recovery on next reconcile
+		_, err = controllerutil.CreateOrPatch(ctx, c, claim, func() error {
+			delete(claim.Annotations, "result-type")
+			return nil
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		// object goes ready after conflict is resolved
+		Eventually(func(g Gomega) {
+			actualClaim := &testv1alpha1.TestClaim{}
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(claim), actualClaim)).To(Succeed())
+			g.Expect(status.ResourceReady(actualClaim)).To(BeTrue())
+		}).Should(Succeed())
+	})
+
 	It("should delete managed resources", func() {
 		// wait for state to be processed
 		Eventually(func(g Gomega) {

--- a/pkg/fsm/internal/test/core/test_fsm_reconciler.go
+++ b/pkg/fsm/internal/test/core/test_fsm_reconciler.go
@@ -268,6 +268,15 @@ func (r *reconciler) testResultTypes() *state {
 					return r.noopState(), fsmtypes.DoneAndRequeueAfterCompletionWithBackoff("Done and requeue after completion with backoff")
 				case "requeue-after-completion":
 					return r.noopState(), fsmtypes.DoneAndRequeueAfterCompletion("Done and requeue after completion", 30*time.Second)
+				case "conflict-on-apply":
+					cm := &corev1.ConfigMap{}
+					if err := r.c.Get(ctx, client.ObjectKey{Name: "conflict-target", Namespace: "default"}, cm); err != nil {
+						return nil, fsmtypes.ErrorResult(fmt.Errorf("getting conflict target: %w", err))
+					}
+					cm.Data = map[string]string{"modified-by": "fsm-transition"}
+					cm.SetResourceVersion("1") // deliberately stale to trigger conflict
+					out.Apply(cm, io.WithOptimisticLock())
+					return nil, fsmtypes.DoneResult()
 				}
 			}
 


### PR DESCRIPTION
## 💸 TL;DR

When Conflict errors occur during OutputSet applies, that error gets propagated back up through the SDK and results in an ErrorResult being emitted by the controller. This queues a retry, which is great, but it also increments error metrics for an expected failure mode. 

This PR looks for the error coming from `applyOutputs` to be a Conflict, and if it is, it sets a custom Reason and propagates a `RequeueResultWithBackoff` up to the caller. 


## 📜 Details
[Jira](https://reddit.atlassian.net/browse/DI-1402)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
ran `make test`, no errors. 

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
