### PR TITLE
`applyOutputs`: Handle conflict with retry instead of error

### DIFF
--- a/pkg/fsm/internal/reconciler.go
+++ b/pkg/fsm/internal/reconciler.go
@@ -290,14 +290,26 @@ func (r *fsmReconciler[T, Obj]) reconcile(
 		}
 
 		if err := r.applyOutputs(ctx, log, obj, out); err != nil {
+			var result types.Result
+			if k8serrors.IsConflict(err) {
+				result = types.RequeueResultWithReasonAndBackoff(
+					fmt.Sprintf("conflict applying outputs: %v", err),
+					"ApplyOutputsConflict",
+				)
+			} else {
+				result = types.ErrorResultWithReason(
+					fmt.Errorf("applying outputs: %w", err),
+					"ApplyOutputsFailed",
+				)
+			}
+
 			// Mark the state's condition as failed since outputs couldn't be applied
 			if !condition.IsEmpty() {
 				condition.Status = corev1.ConditionFalse
-				condition.Reason = "ApplyOutputsFailed"
-				condition.Message = fmt.Sprintf("Failed to apply outputs: %v", err)
+				condition.Message, condition.Reason = result.GetMessageAndReason()
 				conditions.SetConditions(condition)
 			}
-			return obj, conditions, types.ErrorResult(fmt.Errorf("applying outputs: %w", err))
+			return obj, conditions, result
 		}
 
 		// accumulate status conditions, overwrites duplicate conditions with those of later states

--- a/pkg/fsm/internal/reconciler_test.go
+++ b/pkg/fsm/internal/reconciler_test.go
@@ -1,0 +1,162 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/reddit/achilles-sdk-api/api"
+	"github.com/reddit/achilles-sdk/pkg/fsm/metrics"
+	"github.com/reddit/achilles-sdk/pkg/fsm/types"
+	"github.com/reddit/achilles-sdk/pkg/internal/tests/api/test/v1alpha1"
+	"github.com/reddit/achilles-sdk/pkg/io"
+)
+
+const (
+	applyOutputsConditionType = "ApplyOutputs"
+	applyOutputsCMName        = "output-cm"
+)
+
+func TestReconciler_ApplyOutputsErrors(t *testing.T) {
+	const (
+		claimName      = "test-claim"
+		claimNamespace = "default"
+	)
+
+	claim := &v1alpha1.TestClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      claimName,
+			Namespace: claimNamespace,
+		},
+	}
+
+	conflictErr := k8serrors.NewConflict(
+		corev1.Resource("configmaps"),
+		applyOutputsCMName,
+		errors.New("the object has been modified"),
+	)
+	internalErr := errors.New("connection refused")
+
+	tcs := []struct {
+		name           string
+		createErr      error
+		wantRequeue    bool
+		wantErrContain string
+		wantReason     string
+		wantMsgContain string
+	}{
+		{
+			name:           "conflict requeues without error",
+			createErr:      conflictErr,
+			wantRequeue:    true,
+			wantReason:     "ApplyOutputsConflict",
+			wantMsgContain: "conflict applying outputs",
+		},
+		{
+			name:           "non-conflict returns error",
+			createErr:      internalErr,
+			wantErrContain: "applying outputs",
+			wantReason:     "ApplyOutputsFailed",
+			wantMsgContain: "connection refused",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			req := reconcile.Request{NamespacedName: k8stypes.NamespacedName{
+				Name:      claimName,
+				Namespace: claimNamespace,
+			}}
+
+			fakeC := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(claim.DeepCopy()).
+				WithStatusSubresource(claim.DeepCopy()).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+						if obj.GetName() == applyOutputsCMName {
+							return tc.createErr
+						}
+						return c.Create(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			r := newApplyOutputsFSMReconciler(t, fakeC)
+
+			result, err := r.Reconcile(ctx, req)
+			if tc.wantErrContain != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrContain)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantRequeue, result.Requeue)
+
+			gotClaim := &v1alpha1.TestClaim{}
+			require.NoError(t, fakeC.Get(ctx, req.NamespacedName, gotClaim))
+
+			cond := gotClaim.GetCondition(applyOutputsConditionType)
+			assert.Equal(t, corev1.ConditionFalse, cond.Status)
+			assert.Equal(t, api.ConditionReason(tc.wantReason), cond.Reason)
+			assert.Contains(t, cond.Message, tc.wantMsgContain)
+		})
+	}
+}
+
+func newApplyOutputsFSMReconciler(t *testing.T, fakeC client.Client) reconcile.Reconciler {
+	t.Helper()
+
+	log := zaptest.NewLogger(t).Sugar()
+	c := &io.ClientApplicator{
+		Client:     fakeC,
+		Applicator: io.NewAPIPatchingApplicator(fakeC),
+	}
+
+	m := metrics.MustMakeMetrics(scheme, prometheus.NewRegistry())
+	m.InitializeForGVK(v1alpha1.TestClaimGroupVersionKind)
+
+	initialState := &types.State[*v1alpha1.TestClaim]{
+		Name: "apply-outputs",
+		Condition: api.Condition{
+			Type:    applyOutputsConditionType,
+			Message: "Applying outputs",
+		},
+		Transition: func(_ context.Context, claim *v1alpha1.TestClaim, out *types.OutputSet) (*types.State[*v1alpha1.TestClaim], types.Result) {
+			out.Apply(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      applyOutputsCMName,
+					Namespace: claim.GetNamespace(),
+				},
+			})
+			return nil, types.DoneResult()
+		},
+	}
+
+	return NewFSMReconciler(
+		"test-controller",
+		log,
+		c,
+		scheme,
+		initialState,
+		nil,
+		[]schema.GroupVersionKind{corev1.SchemeGroupVersion.WithKind("ConfigMap")},
+		m,
+		types.ReconcilerOptions[v1alpha1.TestClaim, *v1alpha1.TestClaim]{},
+	)
+}

--- a/pkg/fsm/reconciler_test.go
+++ b/pkg/fsm/reconciler_test.go
@@ -1,8 +1,9 @@
-package internal
+package fsm_test
 
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,7 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -20,16 +21,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/reddit/achilles-sdk-api/api"
+	"github.com/reddit/achilles-sdk/pkg/fsm"
 	"github.com/reddit/achilles-sdk/pkg/fsm/metrics"
-	"github.com/reddit/achilles-sdk/pkg/fsm/types"
+	fsmtypes "github.com/reddit/achilles-sdk/pkg/fsm/types"
+	internalscheme "github.com/reddit/achilles-sdk/pkg/internal/scheme"
 	"github.com/reddit/achilles-sdk/pkg/internal/tests/api/test/v1alpha1"
-	"github.com/reddit/achilles-sdk/pkg/io"
 )
 
 const (
 	applyOutputsConditionType = "ApplyOutputs"
 	applyOutputsCMName        = "output-cm"
 )
+
+var scheme = func() *runtime.Scheme {
+	s := internalscheme.MustNewScheme()
+	if err := v1alpha1.AddToScheme(s); err != nil {
+		panic(fmt.Sprintf("failed to initialize test scheme: %s", err))
+	}
+	return s
+}()
 
 func TestReconciler_ApplyOutputsErrors(t *testing.T) {
 	const (
@@ -97,7 +107,7 @@ func TestReconciler_ApplyOutputsErrors(t *testing.T) {
 				}).
 				Build()
 
-			r := newApplyOutputsFSMReconciler(t, fakeC)
+			r := newApplyOutputsReconciler(t, fakeC)
 
 			result, err := r.Reconcile(ctx, req)
 			if tc.wantErrContain != "" {
@@ -119,44 +129,31 @@ func TestReconciler_ApplyOutputsErrors(t *testing.T) {
 	}
 }
 
-func newApplyOutputsFSMReconciler(t *testing.T, fakeC client.Client) reconcile.Reconciler {
+func newApplyOutputsReconciler(t *testing.T, fakeC client.Client) reconcile.Reconciler {
 	t.Helper()
 
 	log := zaptest.NewLogger(t).Sugar()
-	c := &io.ClientApplicator{
-		Client:     fakeC,
-		Applicator: io.NewAPIPatchingApplicator(fakeC),
-	}
-
 	m := metrics.MustMakeMetrics(scheme, prometheus.NewRegistry())
 	m.InitializeForGVK(v1alpha1.TestClaimGroupVersionKind)
 
-	initialState := &types.State[*v1alpha1.TestClaim]{
+	initialState := &fsmtypes.State[*v1alpha1.TestClaim]{
 		Name: "apply-outputs",
 		Condition: api.Condition{
 			Type:    applyOutputsConditionType,
 			Message: "Applying outputs",
 		},
-		Transition: func(_ context.Context, claim *v1alpha1.TestClaim, out *types.OutputSet) (*types.State[*v1alpha1.TestClaim], types.Result) {
+		Transition: func(_ context.Context, claim *v1alpha1.TestClaim, out *fsmtypes.OutputSet) (*fsmtypes.State[*v1alpha1.TestClaim], fsmtypes.Result) {
 			out.Apply(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      applyOutputsCMName,
 					Namespace: claim.GetNamespace(),
 				},
 			})
-			return nil, types.DoneResult()
+			return nil, fsmtypes.DoneResult()
 		},
 	}
 
-	return NewFSMReconciler(
-		"test-controller",
-		log,
-		c,
-		scheme,
-		initialState,
-		nil,
-		[]schema.GroupVersionKind{corev1.SchemeGroupVersion.WithKind("ConfigMap")},
-		m,
-		types.ReconcilerOptions[v1alpha1.TestClaim, *v1alpha1.TestClaim]{},
-	)
+	return fsm.NewBuilder(&v1alpha1.TestClaim{}, initialState, scheme).
+		Manages(corev1.SchemeGroupVersion.WithKind("ConfigMap")).
+		Reconciler(log, scheme, fakeC, m)
 }

--- a/pkg/fsm/reconciler_test.go
+++ b/pkg/fsm/reconciler_test.go
@@ -3,7 +3,6 @@ package fsm_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -33,15 +32,18 @@ const (
 	applyOutputsCMName        = "output-cm"
 )
 
-var scheme = func() *runtime.Scheme {
-	s := internalscheme.MustNewScheme()
-	if err := v1alpha1.AddToScheme(s); err != nil {
-		panic(fmt.Sprintf("failed to initialize test scheme: %s", err))
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	s, err := internalscheme.NewScheme()
+	if err != nil {
+		t.Fatal(err)
 	}
 	return s
-}()
+}
 
 func TestReconciler_ApplyOutputsErrors(t *testing.T) {
+	scheme := testScheme(t)
 	const (
 		claimName      = "test-claim"
 		claimNamespace = "default"
@@ -107,7 +109,7 @@ func TestReconciler_ApplyOutputsErrors(t *testing.T) {
 				}).
 				Build()
 
-			r := newApplyOutputsReconciler(t, fakeC)
+			r := newApplyOutputsReconciler(t, scheme, fakeC)
 
 			result, err := r.Reconcile(ctx, req)
 			if tc.wantErrContain != "" {
@@ -129,7 +131,7 @@ func TestReconciler_ApplyOutputsErrors(t *testing.T) {
 	}
 }
 
-func newApplyOutputsReconciler(t *testing.T, fakeC client.Client) reconcile.Reconciler {
+func newApplyOutputsReconciler(t *testing.T, scheme *runtime.Scheme, fakeC client.Client) reconcile.Reconciler {
 	t.Helper()
 
 	log := zaptest.NewLogger(t).Sugar()


### PR DESCRIPTION
## 💸 TL;DR

This PR updates the `reconcile` function to handle conflict errors with a retry instead of an error.

edit: related PR: https://github.com/reddit/achilles-sdk/pull/116

## 📜 Details

This PR updates the `reconcile` function to handle conflict errors with a retry instead of an error. This is useful as it automatically signals the retry (which should eventually work, as `reconcile` read's the object before it applies) _and_ it prevents `controller_runtime_reconcile_errors_total` from erroneously increasing, which can lead to false positives in alerting.

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee (N/A: Reddit employee)
