### PR TITLE
Fix `WithOptimisticLock` on object creation

### DIFF
--- a/pkg/fsm/types/output_test.go
+++ b/pkg/fsm/types/output_test.go
@@ -90,9 +90,23 @@ func applyOptsEqual(a, b []io.ApplyOption) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	if len(a) == 0 {
-		return true
+	// https://github.com/google/go-cmp/issues/162
+	// this logic is needed for comparing function pointer equality
+	for _, applyOptA := range a {
+		pa := *(*unsafe.Pointer)(unsafe.Pointer(&applyOptA))
+
+		var found bool
+		for _, applyOptB := range b {
+			pb := *(*unsafe.Pointer)(unsafe.Pointer(&applyOptB))
+			if pa == pb {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
 	}
-	// OutputSet stores the slice passed to Apply; compare slice identity.
-	return uintptr(unsafe.Pointer(&a[0])) == uintptr(unsafe.Pointer(&b[0]))
+	return true
 }

--- a/pkg/fsm/types/output_test.go
+++ b/pkg/fsm/types/output_test.go
@@ -90,23 +90,9 @@ func applyOptsEqual(a, b []io.ApplyOption) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	// https://github.com/google/go-cmp/issues/162
-	// this logic is needed for comparing function pointer equality
-	for _, applyOptA := range a {
-		pa := *(*unsafe.Pointer)(unsafe.Pointer(&applyOptA))
-
-		var found bool
-		for _, applyOptB := range b {
-			pb := *(*unsafe.Pointer)(unsafe.Pointer(&applyOptB))
-			if pa == pb {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			return false
-		}
+	if len(a) == 0 {
+		return true
 	}
-	return true
+	// OutputSet stores the slice passed to Apply; compare slice identity.
+	return uintptr(unsafe.Pointer(&a[0])) == uintptr(unsafe.Pointer(&b[0]))
 }

--- a/pkg/io/applicator.go
+++ b/pkg/io/applicator.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/reddit/achilles-sdk/pkg/encoding/json"
-	liberrors "github.com/reddit/achilles-sdk/pkg/errors"
 )
 
 // A ClientApplicator may be used to build a single 'client' that satisfies both
@@ -39,8 +38,31 @@ type Applicator interface {
 	ApplyStatus(context.Context, client.Object, ...ApplyOption) error
 }
 
-// An ApplyOption mutates the desired object before applying
-type ApplyOption func(ctx context.Context, o client.Object, requestOpts *RequestOptions) error
+// ApplyOption configures how Apply/ApplyStatus mutate the desired object and issue requests.
+// Request-level configuration runs before Get/create; object-level configuration requires a non-nil object.
+type ApplyOption struct {
+	configureRequest func(*RequestOptions) error
+	configureObject  func(context.Context, client.Object, *RequestOptions) error
+}
+
+func (o ApplyOption) apply(ctx context.Context, obj client.Object, requestOpts *RequestOptions) error {
+	if o.configureRequest != nil {
+		if err := o.configureRequest(requestOpts); err != nil {
+			return err
+		}
+	}
+	if o.configureObject != nil {
+		return o.configureObject(ctx, obj, requestOpts)
+	}
+	return nil
+}
+
+func (o ApplyOption) configureRequestOnly(requestOpts *RequestOptions) error {
+	if o.configureRequest == nil {
+		return nil
+	}
+	return o.configureRequest(requestOpts)
+}
 
 // options for the kube-apiserver request
 type RequestOptions struct {
@@ -100,14 +122,16 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 	}
 
 	desired := current.DeepCopyObject().(client.Object)
-	// apply options to desired
-	if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
+
+	if err := configureRequestOptions(opts, requestOpts); err != nil {
 		return fmt.Errorf("applying options: %w", err)
 	}
 
-	// if server-side apply is enabled, we should also use it to create the object.
-	// We also bypass the below get + diff loop, meaning that even if an apply doesn't change an object it will update the fieldManagers.
+	// Server-side apply applies options before the Get/create path and bypasses the diff loop.
 	if requestOpts.ServerSideApply {
+		if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
+			return fmt.Errorf("applying options: %w", err)
+		}
 		return a.serverSideApply(ctx, desired, requestOpts)
 	}
 
@@ -120,6 +144,11 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 		return a.createNewObject(ctx, current, requestOpts, opts)
 	} else if err != nil {
 		return fmt.Errorf("cannot get object: %w", err)
+	}
+
+	// apply options to desired after confirming the object exists (or on the create path above).
+	if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
+		return fmt.Errorf("applying options: %w", err)
 	}
 
 	// If there is no difference, we need not perform an update. We convert each into
@@ -151,6 +180,10 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 
 	if reflect.DeepEqual(before, after) {
 		return nil
+	}
+
+	if err := validateOptimisticLock(requestOpts, desired); err != nil {
+		return fmt.Errorf("applying options: %w", err)
 	}
 
 	// request options that modify apply behavior
@@ -210,10 +243,7 @@ func (a *APIApplicator) serverSideApply(ctx context.Context, desired client.Obje
 // createNewObject handles creating a new object with options applied
 func (a *APIApplicator) createNewObject(ctx context.Context, obj client.Object, requestOpts *RequestOptions, opts []ApplyOption) error {
 	// apply options to obj
-	if err := applyOpts(ctx, obj, requestOpts, opts); liberrors.Ignore(func(err error) bool {
-		// ignore optimistic lock error when creating an object because resource version does not yet exist
-		return errors.Is(err, ResourceVersionMissing{})
-	}, err) != nil {
+	if err := applyOpts(ctx, obj, requestOpts, opts); err != nil {
 		return err
 	}
 
@@ -307,11 +337,27 @@ type patch struct{ from runtime.Object }
 func (p *patch) Type() types.PatchType                { return types.MergePatchType }
 func (p *patch) Data(_ client.Object) ([]byte, error) { return json.Marshal(p.from) }
 
-// apply the apply options, mutating the specified object and request opts
+// configureRequestOptions applies request-level options before Get/create.
+func configureRequestOptions(opts []ApplyOption, requestOpts *RequestOptions) error {
+	for _, opt := range opts {
+		if err := opt.configureRequestOnly(requestOpts); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateOptimisticLock(requestOpts *RequestOptions, desired metav1.Object) error {
+	if requestOpts.EnforceOptimisticLock && desired.GetResourceVersion() == "" {
+		return ResourceVersionMissing{}
+	}
+	return nil
+}
+
+// applyOpts applies all options to the specified object and request opts.
 func applyOpts(ctx context.Context, o client.Object, requestOpts *RequestOptions, opts []ApplyOption) error {
-	// apply options
-	for _, fn := range opts {
-		if err := fn(ctx, o, requestOpts); err != nil {
+	for _, opt := range opts {
+		if err := opt.apply(ctx, o, requestOpts); err != nil {
 			return err
 		}
 	}

--- a/pkg/io/applicator.go
+++ b/pkg/io/applicator.go
@@ -99,22 +99,24 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 		return errors.New("cannot access object metadata")
 	}
 
-	desired := current.DeepCopyObject().(client.Object)
+	ssaDesired := current.DeepCopyObject().(client.Object)
+	// apply options to ssaDesired; we do this to mutate
+	// requestOpts so we can properly evaluate requestOpts.ServerSideApply
+	if err := applyOpts(ctx, ssaDesired, requestOpts, opts); err != nil {
+		return fmt.Errorf("applying options: %w", err)
+	}
 
 	// if server-side apply is enabled, we should also use it to create the object.
 	// We also bypass the below get + diff loop, meaning that even if an apply doesn't change an object it will update the fieldManagers.
 	if requestOpts.ServerSideApply {
-		// apply options to desired
-		if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
-			return fmt.Errorf("applying options: %w", err)
-		}
-		return a.serverSideApply(ctx, desired, requestOpts)
+		return a.serverSideApply(ctx, ssaDesired, requestOpts)
 	}
 
 	if m.GetName() == "" && m.GetGenerateName() != "" {
 		return a.createNewObject(ctx, current, requestOpts, opts)
 	}
 
+	desired := current.DeepCopyObject().(client.Object)
 	err := a.client.Get(ctx, types.NamespacedName{Name: m.GetName(), Namespace: m.GetNamespace()}, current)
 	if kerrors.IsNotFound(err) {
 		return a.createNewObject(ctx, current, requestOpts, opts)

--- a/pkg/io/applicator.go
+++ b/pkg/io/applicator.go
@@ -100,14 +100,14 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 	}
 
 	desired := current.DeepCopyObject().(client.Object)
-	// apply options to desired
-	if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
-		return fmt.Errorf("applying options: %w", err)
-	}
 
 	// if server-side apply is enabled, we should also use it to create the object.
 	// We also bypass the below get + diff loop, meaning that even if an apply doesn't change an object it will update the fieldManagers.
 	if requestOpts.ServerSideApply {
+		// apply options to desired
+		if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
+			return fmt.Errorf("applying options: %w", err)
+		}
 		return a.serverSideApply(ctx, desired, requestOpts)
 	}
 
@@ -120,6 +120,11 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 		return a.createNewObject(ctx, current, requestOpts, opts)
 	} else if err != nil {
 		return fmt.Errorf("cannot get object: %w", err)
+	}
+
+	// apply options to desired
+	if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
+		return fmt.Errorf("applying options: %w", err)
 	}
 
 	// If there is no difference, we need not perform an update. We convert each into

--- a/pkg/io/applicator.go
+++ b/pkg/io/applicator.go
@@ -177,7 +177,7 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 	}
 
 	if err := validateOptimisticLock(requestOpts, desired); err != nil {
-		return fmt.Errorf("applying options: %w", err)
+		return fmt.Errorf("applying optimistic lock: %w", err)
 	}
 
 	// request options that modify apply behavior

--- a/pkg/io/applicator.go
+++ b/pkg/io/applicator.go
@@ -100,14 +100,14 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 	}
 
 	desired := current.DeepCopyObject().(client.Object)
+	// apply options to desired
+	if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
+		return fmt.Errorf("applying options: %w", err)
+	}
 
 	// if server-side apply is enabled, we should also use it to create the object.
 	// We also bypass the below get + diff loop, meaning that even if an apply doesn't change an object it will update the fieldManagers.
 	if requestOpts.ServerSideApply {
-		// apply options to desired
-		if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
-			return fmt.Errorf("applying options: %w", err)
-		}
 		return a.serverSideApply(ctx, desired, requestOpts)
 	}
 
@@ -120,11 +120,6 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 		return a.createNewObject(ctx, current, requestOpts, opts)
 	} else if err != nil {
 		return fmt.Errorf("cannot get object: %w", err)
-	}
-
-	// apply options to desired
-	if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
-		return fmt.Errorf("applying options: %w", err)
 	}
 
 	// If there is no difference, we need not perform an update. We convert each into

--- a/pkg/io/applicator.go
+++ b/pkg/io/applicator.go
@@ -100,14 +100,16 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 	}
 
 	desired := current.DeepCopyObject().(client.Object)
-	// apply options to desired
-	if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
+
+	if err := configureRequestOptions(opts, requestOpts); err != nil {
 		return fmt.Errorf("applying options: %w", err)
 	}
 
-	// if server-side apply is enabled, we should also use it to create the object.
-	// We also bypass the below get + diff loop, meaning that even if an apply doesn't change an object it will update the fieldManagers.
+	// Server-side apply applies options before the Get/create path and bypasses the diff loop.
 	if requestOpts.ServerSideApply {
+		if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
+			return fmt.Errorf("applying options: %w", err)
+		}
 		return a.serverSideApply(ctx, desired, requestOpts)
 	}
 
@@ -120,6 +122,11 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 		return a.createNewObject(ctx, current, requestOpts, opts)
 	} else if err != nil {
 		return fmt.Errorf("cannot get object: %w", err)
+	}
+
+	// apply options to desired after confirming the object exists (or on the create path above).
+	if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
+		return fmt.Errorf("applying options: %w", err)
 	}
 
 	// If there is no difference, we need not perform an update. We convert each into
@@ -151,6 +158,10 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 
 	if reflect.DeepEqual(before, after) {
 		return nil
+	}
+
+	if err := validateOptimisticLock(requestOpts, desired); err != nil {
+		return fmt.Errorf("applying options: %w", err)
 	}
 
 	// request options that modify apply behavior
@@ -306,6 +317,25 @@ type patch struct{ from runtime.Object }
 
 func (p *patch) Type() types.PatchType                { return types.MergePatchType }
 func (p *patch) Data(_ client.Object) ([]byte, error) { return json.Marshal(p.from) }
+
+// configureRequestOptions applies opts with a nil object so request-level options
+// (e.g. AsServerSideApply) can be resolved before Get/create. Object-mutating options
+// no-op when the object is nil.
+func configureRequestOptions(opts []ApplyOption, requestOpts *RequestOptions) error {
+	for _, opt := range opts {
+		if err := opt(context.Background(), nil, requestOpts); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateOptimisticLock(requestOpts *RequestOptions, desired metav1.Object) error {
+	if requestOpts.EnforceOptimisticLock && desired.GetResourceVersion() == "" {
+		return ResourceVersionMissing{}
+	}
+	return nil
+}
 
 // apply the apply options, mutating the specified object and request opts
 func applyOpts(ctx context.Context, o client.Object, requestOpts *RequestOptions, opts []ApplyOption) error {

--- a/pkg/io/applicator.go
+++ b/pkg/io/applicator.go
@@ -45,23 +45,18 @@ type ApplyOption struct {
 	configureObject  func(context.Context, client.Object, *RequestOptions) error
 }
 
-func (o ApplyOption) apply(ctx context.Context, obj client.Object, requestOpts *RequestOptions) error {
-	if o.configureRequest != nil {
-		if err := o.configureRequest(requestOpts); err != nil {
-			return err
-		}
-	}
-	if o.configureObject != nil {
-		return o.configureObject(ctx, obj, requestOpts)
-	}
-	return nil
-}
-
 func (o ApplyOption) configureRequestOnly(requestOpts *RequestOptions) error {
 	if o.configureRequest == nil {
 		return nil
 	}
 	return o.configureRequest(requestOpts)
+}
+
+func (o ApplyOption) configureObjectOnly(ctx context.Context, obj client.Object, requestOpts *RequestOptions) error {
+	if o.configureObject == nil {
+		return nil
+	}
+	return o.configureObject(ctx, obj, requestOpts)
 }
 
 // options for the kube-apiserver request
@@ -124,13 +119,13 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 	desired := current.DeepCopyObject().(client.Object)
 
 	if err := configureRequestOptions(opts, requestOpts); err != nil {
-		return fmt.Errorf("applying options: %w", err)
+		return fmt.Errorf("applying request options: %w", err)
 	}
 
-	// Server-side apply applies options before the Get/create path and bypasses the diff loop.
+	// Server-side apply mutates desired and bypasses the Get/create path and diff loop.
 	if requestOpts.ServerSideApply {
-		if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
-			return fmt.Errorf("applying options: %w", err)
+		if err := applyObjectOptions(ctx, desired, requestOpts, opts); err != nil {
+			return fmt.Errorf("applying object options: %w", err)
 		}
 		return a.serverSideApply(ctx, desired, requestOpts)
 	}
@@ -146,9 +141,8 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 		return fmt.Errorf("cannot get object: %w", err)
 	}
 
-	// apply options to desired after confirming the object exists (or on the create path above).
-	if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
-		return fmt.Errorf("applying options: %w", err)
+	if err := applyObjectOptions(ctx, desired, requestOpts, opts); err != nil {
+		return fmt.Errorf("applying object options: %w", err)
 	}
 
 	// If there is no difference, we need not perform an update. We convert each into
@@ -240,11 +234,10 @@ func (a *APIApplicator) serverSideApply(ctx context.Context, desired client.Obje
 	return nil
 }
 
-// createNewObject handles creating a new object with options applied
+// createNewObject handles creating a new object with object options applied.
 func (a *APIApplicator) createNewObject(ctx context.Context, obj client.Object, requestOpts *RequestOptions, opts []ApplyOption) error {
-	// apply options to obj
-	if err := applyOpts(ctx, obj, requestOpts, opts); err != nil {
-		return err
+	if err := applyObjectOptions(ctx, obj, requestOpts, opts); err != nil {
+		return fmt.Errorf("applying object options: %w", err)
 	}
 
 	if err := a.client.Create(ctx, obj); err != nil {
@@ -262,6 +255,10 @@ func (a *APIApplicator) ApplyStatus(ctx context.Context, o client.Object, opts .
 	}
 	requestOpts := &RequestOptions{}
 
+	if err := configureRequestOptions(opts, requestOpts); err != nil {
+		return fmt.Errorf("applying request options: %w", err)
+	}
+
 	current := o.DeepCopyObject().(client.Object) // copy so original object isn't mutated by patch
 	desired := o.DeepCopyObject().(client.Object)
 
@@ -272,9 +269,8 @@ func (a *APIApplicator) ApplyStatus(ctx context.Context, o client.Object, opts .
 		return fmt.Errorf("cannot get object: %w", err)
 	}
 
-	// apply options to desired
-	if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
-		return fmt.Errorf("applying options: %w", err)
+	if err := applyObjectOptions(ctx, desired, requestOpts, opts); err != nil {
+		return fmt.Errorf("applying object options: %w", err)
 	}
 
 	before, err := runtime.DefaultUnstructuredConverter.ToUnstructured(current)
@@ -354,15 +350,15 @@ func validateOptimisticLock(requestOpts *RequestOptions, desired metav1.Object) 
 	return nil
 }
 
-// applyOpts applies all options to the specified object and request opts.
-func applyOpts(ctx context.Context, o client.Object, requestOpts *RequestOptions, opts []ApplyOption) error {
+// applyObjectOptions mutates o using object-level options. requestOpts must already be
+// populated via configureRequestOptions.
+func applyObjectOptions(ctx context.Context, o client.Object, requestOpts *RequestOptions, opts []ApplyOption) error {
 	for _, opt := range opts {
-		if err := opt.apply(ctx, o, requestOpts); err != nil {
+		if err := opt.configureObjectOnly(ctx, o, requestOpts); err != nil {
 			return err
 		}
 	}
 
-	// apply options that mutate object
 	if requestOpts.WithoutOwnerRefs {
 		o.SetOwnerReferences([]metav1.OwnerReference{}) // must explicitly signal deletion when using JSON merge semantics
 	}

--- a/pkg/io/applicator.go
+++ b/pkg/io/applicator.go
@@ -99,24 +99,22 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 		return errors.New("cannot access object metadata")
 	}
 
-	ssaDesired := current.DeepCopyObject().(client.Object)
-	// apply options to ssaDesired; we do this to mutate
-	// requestOpts so we can properly evaluate requestOpts.ServerSideApply
-	if err := applyOpts(ctx, ssaDesired, requestOpts, opts); err != nil {
-		return fmt.Errorf("applying options: %w", err)
-	}
+	desired := current.DeepCopyObject().(client.Object)
 
 	// if server-side apply is enabled, we should also use it to create the object.
 	// We also bypass the below get + diff loop, meaning that even if an apply doesn't change an object it will update the fieldManagers.
 	if requestOpts.ServerSideApply {
-		return a.serverSideApply(ctx, ssaDesired, requestOpts)
+		// apply options to desired
+		if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
+			return fmt.Errorf("applying options: %w", err)
+		}
+		return a.serverSideApply(ctx, desired, requestOpts)
 	}
 
 	if m.GetName() == "" && m.GetGenerateName() != "" {
 		return a.createNewObject(ctx, current, requestOpts, opts)
 	}
 
-	desired := current.DeepCopyObject().(client.Object)
 	err := a.client.Get(ctx, types.NamespacedName{Name: m.GetName(), Namespace: m.GetNamespace()}, current)
 	if kerrors.IsNotFound(err) {
 		return a.createNewObject(ctx, current, requestOpts, opts)

--- a/pkg/io/applicator.go
+++ b/pkg/io/applicator.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/reddit/achilles-sdk/pkg/encoding/json"
-	liberrors "github.com/reddit/achilles-sdk/pkg/errors"
 )
 
 // A ClientApplicator may be used to build a single 'client' that satisfies both
@@ -39,8 +38,31 @@ type Applicator interface {
 	ApplyStatus(context.Context, client.Object, ...ApplyOption) error
 }
 
-// An ApplyOption mutates the desired object before applying
-type ApplyOption func(ctx context.Context, o client.Object, requestOpts *RequestOptions) error
+// ApplyOption configures how Apply/ApplyStatus mutate the desired object and issue requests.
+// Request-level configuration runs before Get/create; object-level configuration requires a non-nil object.
+type ApplyOption struct {
+	configureRequest func(*RequestOptions) error
+	configureObject  func(context.Context, client.Object, *RequestOptions) error
+}
+
+func (o ApplyOption) apply(ctx context.Context, obj client.Object, requestOpts *RequestOptions) error {
+	if o.configureRequest != nil {
+		if err := o.configureRequest(requestOpts); err != nil {
+			return err
+		}
+	}
+	if o.configureObject != nil {
+		return o.configureObject(ctx, obj, requestOpts)
+	}
+	return nil
+}
+
+func (o ApplyOption) configureRequestOnly(requestOpts *RequestOptions) error {
+	if o.configureRequest == nil {
+		return nil
+	}
+	return o.configureRequest(requestOpts)
+}
 
 // options for the kube-apiserver request
 type RequestOptions struct {
@@ -221,10 +243,7 @@ func (a *APIApplicator) serverSideApply(ctx context.Context, desired client.Obje
 // createNewObject handles creating a new object with options applied
 func (a *APIApplicator) createNewObject(ctx context.Context, obj client.Object, requestOpts *RequestOptions, opts []ApplyOption) error {
 	// apply options to obj
-	if err := applyOpts(ctx, obj, requestOpts, opts); liberrors.Ignore(func(err error) bool {
-		// ignore optimistic lock error when creating an object because resource version does not yet exist
-		return errors.Is(err, ResourceVersionMissing{})
-	}, err) != nil {
+	if err := applyOpts(ctx, obj, requestOpts, opts); err != nil {
 		return err
 	}
 
@@ -318,12 +337,10 @@ type patch struct{ from runtime.Object }
 func (p *patch) Type() types.PatchType                { return types.MergePatchType }
 func (p *patch) Data(_ client.Object) ([]byte, error) { return json.Marshal(p.from) }
 
-// configureRequestOptions applies opts with a nil object so request-level options
-// (e.g. AsServerSideApply) can be resolved before Get/create. Object-mutating options
-// no-op when the object is nil.
+// configureRequestOptions applies request-level options before Get/create.
 func configureRequestOptions(opts []ApplyOption, requestOpts *RequestOptions) error {
 	for _, opt := range opts {
-		if err := opt(context.Background(), nil, requestOpts); err != nil {
+		if err := opt.configureRequestOnly(requestOpts); err != nil {
 			return err
 		}
 	}
@@ -337,11 +354,10 @@ func validateOptimisticLock(requestOpts *RequestOptions, desired metav1.Object) 
 	return nil
 }
 
-// apply the apply options, mutating the specified object and request opts
+// applyOpts applies all options to the specified object and request opts.
 func applyOpts(ctx context.Context, o client.Object, requestOpts *RequestOptions, opts []ApplyOption) error {
-	// apply options
-	for _, fn := range opts {
-		if err := fn(ctx, o, requestOpts); err != nil {
+	for _, opt := range opts {
+		if err := opt.apply(ctx, o, requestOpts); err != nil {
 			return err
 		}
 	}

--- a/pkg/io/applicator.go
+++ b/pkg/io/applicator.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/reddit/achilles-sdk/pkg/encoding/json"
+	liberrors "github.com/reddit/achilles-sdk/pkg/errors"
 )
 
 // A ClientApplicator may be used to build a single 'client' that satisfies both
@@ -38,31 +39,8 @@ type Applicator interface {
 	ApplyStatus(context.Context, client.Object, ...ApplyOption) error
 }
 
-// ApplyOption configures how Apply/ApplyStatus mutate the desired object and issue requests.
-// Request-level configuration runs before Get/create; object-level configuration requires a non-nil object.
-type ApplyOption struct {
-	configureRequest func(*RequestOptions) error
-	configureObject  func(context.Context, client.Object, *RequestOptions) error
-}
-
-func (o ApplyOption) apply(ctx context.Context, obj client.Object, requestOpts *RequestOptions) error {
-	if o.configureRequest != nil {
-		if err := o.configureRequest(requestOpts); err != nil {
-			return err
-		}
-	}
-	if o.configureObject != nil {
-		return o.configureObject(ctx, obj, requestOpts)
-	}
-	return nil
-}
-
-func (o ApplyOption) configureRequestOnly(requestOpts *RequestOptions) error {
-	if o.configureRequest == nil {
-		return nil
-	}
-	return o.configureRequest(requestOpts)
-}
+// An ApplyOption mutates the desired object before applying
+type ApplyOption func(ctx context.Context, o client.Object, requestOpts *RequestOptions) error
 
 // options for the kube-apiserver request
 type RequestOptions struct {
@@ -122,16 +100,14 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 	}
 
 	desired := current.DeepCopyObject().(client.Object)
-
-	if err := configureRequestOptions(opts, requestOpts); err != nil {
+	// apply options to desired
+	if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
 		return fmt.Errorf("applying options: %w", err)
 	}
 
-	// Server-side apply applies options before the Get/create path and bypasses the diff loop.
+	// if server-side apply is enabled, we should also use it to create the object.
+	// We also bypass the below get + diff loop, meaning that even if an apply doesn't change an object it will update the fieldManagers.
 	if requestOpts.ServerSideApply {
-		if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
-			return fmt.Errorf("applying options: %w", err)
-		}
 		return a.serverSideApply(ctx, desired, requestOpts)
 	}
 
@@ -144,11 +120,6 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 		return a.createNewObject(ctx, current, requestOpts, opts)
 	} else if err != nil {
 		return fmt.Errorf("cannot get object: %w", err)
-	}
-
-	// apply options to desired after confirming the object exists (or on the create path above).
-	if err := applyOpts(ctx, desired, requestOpts, opts); err != nil {
-		return fmt.Errorf("applying options: %w", err)
 	}
 
 	// If there is no difference, we need not perform an update. We convert each into
@@ -180,10 +151,6 @@ func (a *APIApplicator) Apply(ctx context.Context, current client.Object, opts .
 
 	if reflect.DeepEqual(before, after) {
 		return nil
-	}
-
-	if err := validateOptimisticLock(requestOpts, desired); err != nil {
-		return fmt.Errorf("applying options: %w", err)
 	}
 
 	// request options that modify apply behavior
@@ -243,7 +210,10 @@ func (a *APIApplicator) serverSideApply(ctx context.Context, desired client.Obje
 // createNewObject handles creating a new object with options applied
 func (a *APIApplicator) createNewObject(ctx context.Context, obj client.Object, requestOpts *RequestOptions, opts []ApplyOption) error {
 	// apply options to obj
-	if err := applyOpts(ctx, obj, requestOpts, opts); err != nil {
+	if err := applyOpts(ctx, obj, requestOpts, opts); liberrors.Ignore(func(err error) bool {
+		// ignore optimistic lock error when creating an object because resource version does not yet exist
+		return errors.Is(err, ResourceVersionMissing{})
+	}, err) != nil {
 		return err
 	}
 
@@ -337,27 +307,11 @@ type patch struct{ from runtime.Object }
 func (p *patch) Type() types.PatchType                { return types.MergePatchType }
 func (p *patch) Data(_ client.Object) ([]byte, error) { return json.Marshal(p.from) }
 
-// configureRequestOptions applies request-level options before Get/create.
-func configureRequestOptions(opts []ApplyOption, requestOpts *RequestOptions) error {
-	for _, opt := range opts {
-		if err := opt.configureRequestOnly(requestOpts); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func validateOptimisticLock(requestOpts *RequestOptions, desired metav1.Object) error {
-	if requestOpts.EnforceOptimisticLock && desired.GetResourceVersion() == "" {
-		return ResourceVersionMissing{}
-	}
-	return nil
-}
-
-// applyOpts applies all options to the specified object and request opts.
+// apply the apply options, mutating the specified object and request opts
 func applyOpts(ctx context.Context, o client.Object, requestOpts *RequestOptions, opts []ApplyOption) error {
-	for _, opt := range opts {
-		if err := opt.apply(ctx, o, requestOpts); err != nil {
+	// apply options
+	for _, fn := range opts {
+		if err := fn(ctx, o, requestOpts); err != nil {
 			return err
 		}
 	}

--- a/pkg/io/applicator_test.go
+++ b/pkg/io/applicator_test.go
@@ -394,6 +394,33 @@ var _ = Describe("Applicator", func() {
 			}).Should(Succeed())
 		})
 
+		By("creating the object if it doesn't exist with optimistic lock", func() {
+			svcCreate := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-optimistic-create",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Protocol:   corev1.ProtocolTCP,
+							Port:       8080,
+							TargetPort: intstr.IntOrString{IntVal: 8080},
+						},
+					},
+				},
+			}
+
+			Expect(applicator.Apply(ctx, svcCreate, io.WithOptimisticLock())).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				actual := &corev1.Service{}
+				g.Expect(c.Get(ctx, client.ObjectKeyFromObject(svcCreate), actual)).To(Succeed())
+				g.Expect(actual.Spec.Ports).To(Equal(svcCreate.Spec.Ports))
+			}).Should(Succeed())
+		})
+
 		By("enforcing optimistic lock", func() {
 			// empty resource version in patch should cause failure
 			svc.SetResourceVersion("")

--- a/pkg/io/applicator_test.go
+++ b/pkg/io/applicator_test.go
@@ -394,7 +394,7 @@ var _ = Describe("Applicator", func() {
 			}).Should(Succeed())
 		})
 
-		By("creating the object if it doesn't exist with optimistic lock", func() {
+		By("creating the object if it doesn't exist with optimistic lock (and thus no resource version)", func() {
 			svcCreate := &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "svc-optimistic-create",

--- a/pkg/io/options.go
+++ b/pkg/io/options.go
@@ -13,6 +13,9 @@ import (
 // WithRedditLabels applies a standard set of labels for managed resources.
 func WithRedditLabels(controllerName string) ApplyOption {
 	return func(ctx context.Context, o client.Object, _ *RequestOptions) error {
+		if o == nil {
+			return nil
+		}
 		meta.SetRedditLabels(o, controllerName)
 		return nil
 	}
@@ -22,6 +25,9 @@ func WithRedditLabels(controllerName string) ApplyOption {
 // When used in the context of OutputSet, this option is used by default unless WithoutOwnerRef is specified.
 func WithControllerRef(owner client.Object, scheme *runtime.Scheme) ApplyOption {
 	return func(ctx context.Context, o client.Object, opts *RequestOptions) error {
+		if o == nil {
+			return nil
+		}
 		// skip if WithoutOwnerRefs is set or if the caller explicitly specifies ownerReferences
 		if opts.WithoutOwnerRefs || opts.hasExplicitOwnerRefs {
 			return nil
@@ -39,6 +45,9 @@ func WithOwnerRef(owner client.Object, scheme *runtime.Scheme) ApplyOption {
 			return nil
 		}
 		opts.hasExplicitOwnerRefs = true // prevent FSM reconciler from adding the default controller reference
+		if o == nil {
+			return nil
+		}
 		return meta.SetOwnerRef(o, owner, scheme)
 	}
 }
@@ -53,12 +62,10 @@ func WithoutOwnerRefs() ApplyOption {
 	}
 }
 
-// WithOptimisticLock returns an error if the desired object is missing the resource version
+// WithOptimisticLock requires the desired object to include a resource version when patching
+// or updating an existing object. The check is deferred until apply time so creates are not blocked.
 func WithOptimisticLock() ApplyOption {
-	return func(ctx context.Context, o client.Object, opts *RequestOptions) error {
-		if o.GetResourceVersion() == "" {
-			return ResourceVersionMissing{}
-		}
+	return func(_ context.Context, _ client.Object, opts *RequestOptions) error {
 		opts.EnforceOptimisticLock = true
 		return nil
 	}

--- a/pkg/io/options.go
+++ b/pkg/io/options.go
@@ -12,41 +12,34 @@ import (
 
 // WithRedditLabels applies a standard set of labels for managed resources.
 func WithRedditLabels(controllerName string) ApplyOption {
-	return objectOption(func(_ context.Context, o client.Object, _ *RequestOptions) error {
+	return func(ctx context.Context, o client.Object, _ *RequestOptions) error {
 		meta.SetRedditLabels(o, controllerName)
 		return nil
-	})
+	}
 }
 
 // WithControllerRef sets an owner reference on the object and controller flag to true.
 // When used in the context of OutputSet, this option is used by default unless WithoutOwnerRef is specified.
 func WithControllerRef(owner client.Object, scheme *runtime.Scheme) ApplyOption {
-	return objectOption(func(_ context.Context, o client.Object, opts *RequestOptions) error {
+	return func(ctx context.Context, o client.Object, opts *RequestOptions) error {
 		// skip if WithoutOwnerRefs is set or if the caller explicitly specifies ownerReferences
 		if opts.WithoutOwnerRefs || opts.hasExplicitOwnerRefs {
 			return nil
 		}
 		return meta.SetControllerRef(o, owner, scheme)
-	})
+	}
 }
 
 // WithOwnerRef sets an owner reference on the object and controller flag to false.
 // Multiple owner references can be set on an object if their controller flag is false.
 func WithOwnerRef(owner client.Object, scheme *runtime.Scheme) ApplyOption {
-	return ApplyOption{
-		configureRequest: func(requestOpts *RequestOptions) error {
-			if requestOpts.WithoutOwnerRefs {
-				return nil
-			}
-			requestOpts.hasExplicitOwnerRefs = true // prevent FSM reconciler from adding the default controller reference
+	return func(ctx context.Context, o client.Object, opts *RequestOptions) error {
+		// skip if WithoutOwnerRefs is set
+		if opts.WithoutOwnerRefs {
 			return nil
-		},
-		configureObject: func(_ context.Context, o client.Object, requestOpts *RequestOptions) error {
-			if requestOpts.WithoutOwnerRefs {
-				return nil
-			}
-			return meta.SetOwnerRef(o, owner, scheme)
-		},
+		}
+		opts.hasExplicitOwnerRefs = true // prevent FSM reconciler from adding the default controller reference
+		return meta.SetOwnerRef(o, owner, scheme)
 	}
 }
 
@@ -54,28 +47,30 @@ func WithOwnerRef(owner client.Object, scheme *runtime.Scheme) ApplyOption {
 // Generally this should not be used—only set it if your controller is intentionally managing owner references on
 // managed resources.
 func WithoutOwnerRefs() ApplyOption {
-	return requestOption(func(requestOpts *RequestOptions) error {
+	return func(ctx context.Context, o client.Object, requestOpts *RequestOptions) error {
 		requestOpts.WithoutOwnerRefs = true
 		return nil
-	})
+	}
 }
 
-// WithOptimisticLock requires the desired object to include a resource version when patching
-// or updating an existing object. The check is deferred until apply time so creates are not blocked.
+// WithOptimisticLock returns an error if the desired object is missing the resource version
 func WithOptimisticLock() ApplyOption {
-	return requestOption(func(requestOpts *RequestOptions) error {
-		requestOpts.EnforceOptimisticLock = true
+	return func(ctx context.Context, o client.Object, opts *RequestOptions) error {
+		if o.GetResourceVersion() == "" {
+			return ResourceVersionMissing{}
+		}
+		opts.EnforceOptimisticLock = true
 		return nil
-	})
+	}
 }
 
 // AsUpdate uses an update request to overwrite the entire object if it exists, rather than selective patching.
 // Using this option without the optimistic lock implies a full overwrite of the object, so use with caution.
 func AsUpdate() ApplyOption {
-	return requestOption(func(requestOpts *RequestOptions) error {
+	return func(ctx context.Context, _ client.Object, requestOpts *RequestOptions) error {
 		requestOpts.Update = true
 		return nil
-	})
+	}
 }
 
 // AsServerSideApply causes Apply (and ApplyStatus) to use server-side apply (PATCH with ApplyPatchType)
@@ -93,14 +88,14 @@ func AsUpdate() ApplyOption {
 //     omitted from the JSON body and will NOT be set to zero — they will instead release ownership.
 //     Use pointer types (*int, *string, etc.) for fields you need to explicitly zero via SSA.
 func AsServerSideApply(fieldManager string) ApplyOption {
-	return requestOption(func(requestOpts *RequestOptions) error {
+	return func(ctx context.Context, _ client.Object, requestOpts *RequestOptions) error {
 		if fieldManager == "" {
 			return fmt.Errorf("AsServerSideApply requires a non-empty fieldManager name")
 		}
 		requestOpts.ServerSideApply = true
 		requestOpts.FieldManager = fieldManager
 		return nil
-	})
+	}
 }
 
 // WithForceOwnership, when used with AsServerSideApply, sends ?force=true to claim ownership of fields
@@ -112,16 +107,8 @@ func AsServerSideApply(fieldManager string) ApplyOption {
 //
 // No-op when AsServerSideApply is not also set.
 func WithForceOwnership() ApplyOption {
-	return requestOption(func(requestOpts *RequestOptions) error {
+	return func(ctx context.Context, _ client.Object, requestOpts *RequestOptions) error {
 		requestOpts.ForceOwnership = true
 		return nil
-	})
-}
-
-func requestOption(fn func(*RequestOptions) error) ApplyOption {
-	return ApplyOption{configureRequest: fn}
-}
-
-func objectOption(fn func(context.Context, client.Object, *RequestOptions) error) ApplyOption {
-	return ApplyOption{configureObject: fn}
+	}
 }

--- a/pkg/io/options.go
+++ b/pkg/io/options.go
@@ -12,34 +12,41 @@ import (
 
 // WithRedditLabels applies a standard set of labels for managed resources.
 func WithRedditLabels(controllerName string) ApplyOption {
-	return func(ctx context.Context, o client.Object, _ *RequestOptions) error {
+	return objectOption(func(_ context.Context, o client.Object, _ *RequestOptions) error {
 		meta.SetRedditLabels(o, controllerName)
 		return nil
-	}
+	})
 }
 
 // WithControllerRef sets an owner reference on the object and controller flag to true.
 // When used in the context of OutputSet, this option is used by default unless WithoutOwnerRef is specified.
 func WithControllerRef(owner client.Object, scheme *runtime.Scheme) ApplyOption {
-	return func(ctx context.Context, o client.Object, opts *RequestOptions) error {
+	return objectOption(func(_ context.Context, o client.Object, opts *RequestOptions) error {
 		// skip if WithoutOwnerRefs is set or if the caller explicitly specifies ownerReferences
 		if opts.WithoutOwnerRefs || opts.hasExplicitOwnerRefs {
 			return nil
 		}
 		return meta.SetControllerRef(o, owner, scheme)
-	}
+	})
 }
 
 // WithOwnerRef sets an owner reference on the object and controller flag to false.
 // Multiple owner references can be set on an object if their controller flag is false.
 func WithOwnerRef(owner client.Object, scheme *runtime.Scheme) ApplyOption {
-	return func(ctx context.Context, o client.Object, opts *RequestOptions) error {
-		// skip if WithoutOwnerRefs is set
-		if opts.WithoutOwnerRefs {
+	return ApplyOption{
+		configureRequest: func(requestOpts *RequestOptions) error {
+			if requestOpts.WithoutOwnerRefs {
+				return nil
+			}
+			requestOpts.hasExplicitOwnerRefs = true // prevent FSM reconciler from adding the default controller reference
 			return nil
-		}
-		opts.hasExplicitOwnerRefs = true // prevent FSM reconciler from adding the default controller reference
-		return meta.SetOwnerRef(o, owner, scheme)
+		},
+		configureObject: func(_ context.Context, o client.Object, requestOpts *RequestOptions) error {
+			if requestOpts.WithoutOwnerRefs {
+				return nil
+			}
+			return meta.SetOwnerRef(o, owner, scheme)
+		},
 	}
 }
 
@@ -47,30 +54,28 @@ func WithOwnerRef(owner client.Object, scheme *runtime.Scheme) ApplyOption {
 // Generally this should not be used—only set it if your controller is intentionally managing owner references on
 // managed resources.
 func WithoutOwnerRefs() ApplyOption {
-	return func(ctx context.Context, o client.Object, requestOpts *RequestOptions) error {
+	return requestOption(func(requestOpts *RequestOptions) error {
 		requestOpts.WithoutOwnerRefs = true
 		return nil
-	}
+	})
 }
 
-// WithOptimisticLock returns an error if the desired object is missing the resource version
+// WithOptimisticLock requires the desired object to include a resource version when patching
+// or updating an existing object. The check is deferred until apply time so creates are not blocked.
 func WithOptimisticLock() ApplyOption {
-	return func(ctx context.Context, o client.Object, opts *RequestOptions) error {
-		if o.GetResourceVersion() == "" {
-			return ResourceVersionMissing{}
-		}
-		opts.EnforceOptimisticLock = true
+	return requestOption(func(requestOpts *RequestOptions) error {
+		requestOpts.EnforceOptimisticLock = true
 		return nil
-	}
+	})
 }
 
 // AsUpdate uses an update request to overwrite the entire object if it exists, rather than selective patching.
 // Using this option without the optimistic lock implies a full overwrite of the object, so use with caution.
 func AsUpdate() ApplyOption {
-	return func(ctx context.Context, _ client.Object, requestOpts *RequestOptions) error {
+	return requestOption(func(requestOpts *RequestOptions) error {
 		requestOpts.Update = true
 		return nil
-	}
+	})
 }
 
 // AsServerSideApply causes Apply (and ApplyStatus) to use server-side apply (PATCH with ApplyPatchType)
@@ -88,14 +93,14 @@ func AsUpdate() ApplyOption {
 //     omitted from the JSON body and will NOT be set to zero — they will instead release ownership.
 //     Use pointer types (*int, *string, etc.) for fields you need to explicitly zero via SSA.
 func AsServerSideApply(fieldManager string) ApplyOption {
-	return func(ctx context.Context, _ client.Object, requestOpts *RequestOptions) error {
+	return requestOption(func(requestOpts *RequestOptions) error {
 		if fieldManager == "" {
 			return fmt.Errorf("AsServerSideApply requires a non-empty fieldManager name")
 		}
 		requestOpts.ServerSideApply = true
 		requestOpts.FieldManager = fieldManager
 		return nil
-	}
+	})
 }
 
 // WithForceOwnership, when used with AsServerSideApply, sends ?force=true to claim ownership of fields
@@ -107,8 +112,16 @@ func AsServerSideApply(fieldManager string) ApplyOption {
 //
 // No-op when AsServerSideApply is not also set.
 func WithForceOwnership() ApplyOption {
-	return func(ctx context.Context, _ client.Object, requestOpts *RequestOptions) error {
+	return requestOption(func(requestOpts *RequestOptions) error {
 		requestOpts.ForceOwnership = true
 		return nil
-	}
+	})
+}
+
+func requestOption(fn func(*RequestOptions) error) ApplyOption {
+	return ApplyOption{configureRequest: fn}
+}
+
+func objectOption(fn func(context.Context, client.Object, *RequestOptions) error) ApplyOption {
+	return ApplyOption{configureObject: fn}
 }

--- a/pkg/io/options.go
+++ b/pkg/io/options.go
@@ -12,43 +12,41 @@ import (
 
 // WithRedditLabels applies a standard set of labels for managed resources.
 func WithRedditLabels(controllerName string) ApplyOption {
-	return func(ctx context.Context, o client.Object, _ *RequestOptions) error {
-		if o == nil {
-			return nil
-		}
+	return objectOption(func(_ context.Context, o client.Object, _ *RequestOptions) error {
 		meta.SetRedditLabels(o, controllerName)
 		return nil
-	}
+	})
 }
 
 // WithControllerRef sets an owner reference on the object and controller flag to true.
 // When used in the context of OutputSet, this option is used by default unless WithoutOwnerRef is specified.
 func WithControllerRef(owner client.Object, scheme *runtime.Scheme) ApplyOption {
-	return func(ctx context.Context, o client.Object, opts *RequestOptions) error {
-		if o == nil {
-			return nil
-		}
+	return objectOption(func(_ context.Context, o client.Object, opts *RequestOptions) error {
 		// skip if WithoutOwnerRefs is set or if the caller explicitly specifies ownerReferences
 		if opts.WithoutOwnerRefs || opts.hasExplicitOwnerRefs {
 			return nil
 		}
 		return meta.SetControllerRef(o, owner, scheme)
-	}
+	})
 }
 
 // WithOwnerRef sets an owner reference on the object and controller flag to false.
 // Multiple owner references can be set on an object if their controller flag is false.
 func WithOwnerRef(owner client.Object, scheme *runtime.Scheme) ApplyOption {
-	return func(ctx context.Context, o client.Object, opts *RequestOptions) error {
-		// skip if WithoutOwnerRefs is set
-		if opts.WithoutOwnerRefs {
+	return ApplyOption{
+		configureRequest: func(requestOpts *RequestOptions) error {
+			if requestOpts.WithoutOwnerRefs {
+				return nil
+			}
+			requestOpts.hasExplicitOwnerRefs = true // prevent FSM reconciler from adding the default controller reference
 			return nil
-		}
-		opts.hasExplicitOwnerRefs = true // prevent FSM reconciler from adding the default controller reference
-		if o == nil {
-			return nil
-		}
-		return meta.SetOwnerRef(o, owner, scheme)
+		},
+		configureObject: func(_ context.Context, o client.Object, requestOpts *RequestOptions) error {
+			if requestOpts.WithoutOwnerRefs {
+				return nil
+			}
+			return meta.SetOwnerRef(o, owner, scheme)
+		},
 	}
 }
 
@@ -56,28 +54,28 @@ func WithOwnerRef(owner client.Object, scheme *runtime.Scheme) ApplyOption {
 // Generally this should not be used—only set it if your controller is intentionally managing owner references on
 // managed resources.
 func WithoutOwnerRefs() ApplyOption {
-	return func(ctx context.Context, o client.Object, requestOpts *RequestOptions) error {
+	return requestOption(func(requestOpts *RequestOptions) error {
 		requestOpts.WithoutOwnerRefs = true
 		return nil
-	}
+	})
 }
 
 // WithOptimisticLock requires the desired object to include a resource version when patching
 // or updating an existing object. The check is deferred until apply time so creates are not blocked.
 func WithOptimisticLock() ApplyOption {
-	return func(_ context.Context, _ client.Object, opts *RequestOptions) error {
-		opts.EnforceOptimisticLock = true
+	return requestOption(func(requestOpts *RequestOptions) error {
+		requestOpts.EnforceOptimisticLock = true
 		return nil
-	}
+	})
 }
 
 // AsUpdate uses an update request to overwrite the entire object if it exists, rather than selective patching.
 // Using this option without the optimistic lock implies a full overwrite of the object, so use with caution.
 func AsUpdate() ApplyOption {
-	return func(ctx context.Context, _ client.Object, requestOpts *RequestOptions) error {
+	return requestOption(func(requestOpts *RequestOptions) error {
 		requestOpts.Update = true
 		return nil
-	}
+	})
 }
 
 // AsServerSideApply causes Apply (and ApplyStatus) to use server-side apply (PATCH with ApplyPatchType)
@@ -95,14 +93,14 @@ func AsUpdate() ApplyOption {
 //     omitted from the JSON body and will NOT be set to zero — they will instead release ownership.
 //     Use pointer types (*int, *string, etc.) for fields you need to explicitly zero via SSA.
 func AsServerSideApply(fieldManager string) ApplyOption {
-	return func(ctx context.Context, _ client.Object, requestOpts *RequestOptions) error {
+	return requestOption(func(requestOpts *RequestOptions) error {
 		if fieldManager == "" {
 			return fmt.Errorf("AsServerSideApply requires a non-empty fieldManager name")
 		}
 		requestOpts.ServerSideApply = true
 		requestOpts.FieldManager = fieldManager
 		return nil
-	}
+	})
 }
 
 // WithForceOwnership, when used with AsServerSideApply, sends ?force=true to claim ownership of fields
@@ -114,8 +112,16 @@ func AsServerSideApply(fieldManager string) ApplyOption {
 //
 // No-op when AsServerSideApply is not also set.
 func WithForceOwnership() ApplyOption {
-	return func(ctx context.Context, _ client.Object, requestOpts *RequestOptions) error {
+	return requestOption(func(requestOpts *RequestOptions) error {
 		requestOpts.ForceOwnership = true
 		return nil
-	}
+	})
+}
+
+func requestOption(fn func(*RequestOptions) error) ApplyOption {
+	return ApplyOption{configureRequest: fn}
+}
+
+func objectOption(fn func(context.Context, client.Object, *RequestOptions) error) ApplyOption {
+	return ApplyOption{configureObject: fn}
 }

--- a/pkg/io/options.go
+++ b/pkg/io/options.go
@@ -17,7 +17,7 @@ func requestOption(fn func(*RequestOptions) error) ApplyOption {
 	return ApplyOption{configureRequest: fn}
 }
 
-// objectOption builds an ApplyOption whose hook runs only during applyObjectOptions.
+// objectOption is an option that mutates the object being created or updated.
 // Use it to mutate the desired object (labels, owner references) once request options are
 // resolved and the applicator has a concrete object to send (create, patch, or SSA).
 func objectOption(fn func(context.Context, client.Object, *RequestOptions) error) ApplyOption {

--- a/pkg/io/options.go
+++ b/pkg/io/options.go
@@ -10,6 +10,20 @@ import (
 	"github.com/reddit/achilles-sdk/pkg/meta"
 )
 
+// requestOption builds an ApplyOption whose hook runs only during configureRequestOptions.
+// Use it for flags that affect how Apply/ApplyStatus talk to the API (patch vs update, SSA,
+// optimistic lock) and must be known before Get or create, without mutating the desired object.
+func requestOption(fn func(*RequestOptions) error) ApplyOption {
+	return ApplyOption{configureRequest: fn}
+}
+
+// objectOption builds an ApplyOption whose hook runs only during applyObjectOptions.
+// Use it to mutate the desired object (labels, owner references) once request options are
+// resolved and the applicator has a concrete object to send (create, patch, or SSA).
+func objectOption(fn func(context.Context, client.Object, *RequestOptions) error) ApplyOption {
+	return ApplyOption{configureObject: fn}
+}
+
 // WithRedditLabels applies a standard set of labels for managed resources.
 func WithRedditLabels(controllerName string) ApplyOption {
 	return objectOption(func(_ context.Context, o client.Object, _ *RequestOptions) error {
@@ -116,12 +130,4 @@ func WithForceOwnership() ApplyOption {
 		requestOpts.ForceOwnership = true
 		return nil
 	})
-}
-
-func requestOption(fn func(*RequestOptions) error) ApplyOption {
-	return ApplyOption{configureRequest: fn}
-}
-
-func objectOption(fn func(context.Context, client.Object, *RequestOptions) error) ApplyOption {
-	return ApplyOption{configureObject: fn}
 }

--- a/pkg/io/options.go
+++ b/pkg/io/options.go
@@ -10,7 +10,7 @@ import (
 	"github.com/reddit/achilles-sdk/pkg/meta"
 )
 
-// requestOption builds an ApplyOption whose hook runs only during configureRequestOptions.
+// requestOption is an option that affects how the Kubernetes request is performed.
 // Use it for flags that affect how Apply/ApplyStatus talk to the API (patch vs update, SSA,
 // optimistic lock) and must be known before Get or create, without mutating the desired object.
 func requestOption(fn func(*RequestOptions) error) ApplyOption {


### PR DESCRIPTION
## 💸 TL;DR

There was a regression in https://github.com/reddit/achilles-sdk/pull/113 for SDK users of the `WithOptimisticLock()` option on object creation. This PR fixes the regression.

## 📜 Details

The problem: `WithOptimisticLock()` is only valid for PUT requests, it doesn't make sense for server side apply. In https://github.com/reddit/achilles-sdk/pull/113 the logic was changed:

v0.13.13 flow (correct):

1. Get object
1. If NotFound → createNewObject → apply opts (ignore ResourceVersionMissing) → Create
1. If exists → apply opts on desired → diff → patch

v0.13.14 flow (broken):

1. Apply opts immediately → WithOptimisticLock() errors because RV is empty
1. Never reaches Get or createNewObject

This PR restores the v0.13.13 flow for the Get + Create codepath but also keeps the early options apply for the SSA codepath.

## 🧪 Testing Steps / Validation

Validated against failing internal envtests as well as the new test coverage added in this PR.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee (Reddit employee)
