### PR TITLE
Ignore reconcile errors caused by a done context

### DIFF
--- a/pkg/fsm/internal/reconciler.go
+++ b/pkg/fsm/internal/reconciler.go
@@ -89,7 +89,6 @@ func (r *fsmReconciler[T, Obj]) Reconcile(ctx context.Context, req ctrl.Request)
 	log.Debug("entering reconcile")
 	startedAt := time.Now()
 	defer func() { log.Debugf("finished reconcile in %s", time.Since(startedAt)) }()
-
 	defer func() {
 		res, err = ignoreErrorsAfterContextDone(ctx, log, res, err)
 	}()
@@ -99,7 +98,6 @@ func (r *fsmReconciler[T, Obj]) Reconcile(ctx context.Context, req ctrl.Request)
 		// fetch the object's latest state
 		obj := Obj(new(T))
 		if err := r.client.Get(ctx, req.NamespacedName, obj); err != nil {
-			// shutdown cancels this fetch along with the reconcile, making the failure expected
 			if !k8serrors.IsNotFound(err) && ctx.Err() == nil {
 				log.Errorf("fetching object for recording metrics: %s", err)
 			}
@@ -164,22 +162,24 @@ func (r *fsmReconciler[T, Obj]) Reconcile(ctx context.Context, req ctrl.Request)
 	return result.Get(log)
 }
 
-// ignoreErrorsAfterContextDone discards a reconcile's result and error if its context is done. The manager cancels the
-// context of every in-flight reconcile when it shuts down, which fails all of their outstanding API requests. Those
-// errors are expected and cannot be acted upon because the work queue is shutting down as well. Returning an empty
-// result and a nil error keeps controller-runtime from counting the reconcile as a failure or requeueing work that the
-// shutting-down queue would drop anyway.
+// When the controller is shut down, it cancels the context of every in-progress Reconcile(). This fails every
+// reconciler's outstanding API requests with an error like "client rate limiter Wait returned an error: context canceled".
+// These errors are expected and cannot be acted upon. Ignore them instead of returning an error.
 func ignoreErrorsAfterContextDone(
 	ctx context.Context,
 	log *zap.SugaredLogger,
 	res ctrl.Result,
 	err error,
 ) (ctrl.Result, error) {
+	// If there is no error, continue as normal
 	if err == nil || ctx.Err() == nil {
 		return res, err
 	}
 
+	// The context was Canceled or DeadlineExceeded
 	log.Debugf("aborting reconcile, context is done: %s", err)
+	// Return an empty result and a nil error to prevent controller-runtime from counting the reconcile as a failure and
+	// requeueing the work
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/fsm/internal/reconciler.go
+++ b/pkg/fsm/internal/reconciler.go
@@ -90,13 +90,17 @@ func (r *fsmReconciler[T, Obj]) Reconcile(ctx context.Context, req ctrl.Request)
 	startedAt := time.Now()
 	defer func() { log.Debugf("finished reconcile in %s", time.Since(startedAt)) }()
 
+	defer func() {
+		res, err = ignoreErrorsAfterContextDone(ctx, log, res, err)
+	}()
+
 	// record metrics
 	defer func() {
 		// fetch the object's latest state
 		obj := Obj(new(T))
 		if err := r.client.Get(ctx, req.NamespacedName, obj); err != nil {
-			if !k8serrors.IsNotFound(err) {
-				log.Error("fetching object for recording metrics: %w", err)
+			if !k8serrors.IsNotFound(err) && ctx.Err() == nil {
+				log.Errorf("fetching object for recording metrics: %s", err)
 			}
 			return
 		}
@@ -157,6 +161,23 @@ func (r *fsmReconciler[T, Obj]) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	return result.Get(log)
+}
+
+// ignoreErrorsAfterContextDone discards a reconcile's result and error if its context is done. The manager cancels the
+// context of every in-flight reconcile when it shuts down, which fails all of their outstanding API requests. Those
+// errors are expected and cannot be acted upon because the work queue is shutting down as well.
+func ignoreErrorsAfterContextDone(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	res ctrl.Result,
+	err error,
+) (ctrl.Result, error) {
+	if err == nil || ctx.Err() == nil {
+		return res, err
+	}
+
+	log.Debugf("aborting reconcile, context is done: %s", err)
+	return ctrl.Result{}, nil
 }
 
 // reconcile the object through a sequence of FSM states

--- a/pkg/fsm/internal/reconciler.go
+++ b/pkg/fsm/internal/reconciler.go
@@ -99,6 +99,7 @@ func (r *fsmReconciler[T, Obj]) Reconcile(ctx context.Context, req ctrl.Request)
 		// fetch the object's latest state
 		obj := Obj(new(T))
 		if err := r.client.Get(ctx, req.NamespacedName, obj); err != nil {
+			// shutdown cancels this fetch along with the reconcile, making the failure expected
 			if !k8serrors.IsNotFound(err) && ctx.Err() == nil {
 				log.Errorf("fetching object for recording metrics: %s", err)
 			}
@@ -165,7 +166,9 @@ func (r *fsmReconciler[T, Obj]) Reconcile(ctx context.Context, req ctrl.Request)
 
 // ignoreErrorsAfterContextDone discards a reconcile's result and error if its context is done. The manager cancels the
 // context of every in-flight reconcile when it shuts down, which fails all of their outstanding API requests. Those
-// errors are expected and cannot be acted upon because the work queue is shutting down as well.
+// errors are expected and cannot be acted upon because the work queue is shutting down as well. Returning an empty
+// result and a nil error keeps controller-runtime from counting the reconcile as a failure or requeueing work that the
+// shutting-down queue would drop anyway.
 func ignoreErrorsAfterContextDone(
 	ctx context.Context,
 	log *zap.SugaredLogger,

--- a/pkg/fsm/internal/reconciler_claim.go
+++ b/pkg/fsm/internal/reconciler_claim.go
@@ -44,12 +44,15 @@ type BeforeDelete[
 	T any, Claimed apitypes.ClaimedType[T], U any, Claim apitypes.ClaimType[U],
 ] func(Claim, Claimed) error
 
-func (r *ClaimReconciler[T, Claimed, U, Claim]) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *ClaimReconciler[T, Claimed, U, Claim]) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	requestId := ctrlcontroller.ReconcileIDFromContext(ctx)
 	log := r.Log.With("request", req, "requestId", requestId)
 	log.Debug("entering reconcile")
 	startedAt := time.Now()
 	defer func() { log.Debugf("finished reconcile in %s", time.Since(startedAt)) }()
+	defer func() {
+		res, err = ignoreErrorsAfterContextDone(ctx, log, res, err)
+	}()
 
 	claim := Claim(new(U))
 	if err := r.Client.Get(ctx, req.NamespacedName, claim); k8serrors.IsNotFound(err) {

--- a/pkg/fsm/internal/reconciler_claim_test.go
+++ b/pkg/fsm/internal/reconciler_claim_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/reddit/achilles-sdk-api/api"
@@ -32,6 +33,8 @@ const (
 var (
 	now    = metav1.NewTime(time.Now().Round(time.Second))
 	scheme = internalscheme.MustNewScheme()
+
+	errGet = errors.New("get failed")
 )
 
 func init() {
@@ -154,6 +157,74 @@ func TestReconciler_Claim(t *testing.T) {
 					cmpopts.IgnoreTypes(metav1.TypeMeta{})); diff != "" {
 					t.Errorf("object differs from expected: (-got +want)\n%s", diff)
 				}
+			}
+		})
+	}
+}
+
+// TestReconciler_Claim_ContextDone asserts that errors encountered after the reconcile context is done are not
+// surfaced as reconcile errors.
+func TestReconciler_Claim_ContextDone(t *testing.T) {
+	cases := []struct {
+		name      string
+		cancelCtx bool
+		wantErr   error
+	}{
+		{
+			name:    "surfaces_get_errors",
+			wantErr: errGet,
+		},
+		{
+			name:      "ignores_errors_once_context_is_done",
+			cancelCtx: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tc.cancelCtx {
+				cancel()
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(newTestClaim()).
+				Build()
+
+			// mimic the API client, which fails all requests once their context is done
+			c := interceptor.NewClient(fakeClient, interceptor.Funcs{
+				Get: func(
+					ctx context.Context,
+					_ client.WithWatch,
+					_ client.ObjectKey,
+					_ client.Object,
+					_ ...client.GetOption,
+				) error {
+					if err := ctx.Err(); err != nil {
+						return fmt.Errorf("client rate limiter Wait returned an error: %w", err)
+					}
+					return errGet
+				},
+			})
+
+			r := NewClaimReconciler(&v1alpha1.TestClaimed{}, &v1alpha1.TestClaim{}, testApplicator(c), scheme, zaptest.NewLogger(t).Sugar(), nil)
+
+			res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: testClaimName}})
+
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("expected no error, got: %s", err)
+				}
+				if !res.IsZero() {
+					t.Errorf("expected an empty result, got: %+v", res)
+				}
+				return
+			}
+
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error running reconciler did not match expected\ngot: %v\nwant: %s", err, tc.wantErr)
 			}
 		})
 	}

--- a/pkg/fsm/internal/reconciler_test.go
+++ b/pkg/fsm/internal/reconciler_test.go
@@ -1,0 +1,110 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap/zaptest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/reddit/achilles-sdk-api/api"
+	"github.com/reddit/achilles-sdk/pkg/fsm/metrics"
+	fsmtypes "github.com/reddit/achilles-sdk/pkg/fsm/types"
+	"github.com/reddit/achilles-sdk/pkg/internal/tests/api/test/v1alpha1"
+)
+
+const testFSMObjectName = "test-fsm-object"
+
+var errStatusPatch = errors.New("status patch failed")
+
+// TestReconcile_ContextDone asserts that errors encountered after the reconcile context is done are not surfaced as
+// reconcile errors. The manager cancels the context of every in-flight reconcile when it shuts down, which fails all
+// of their outstanding API requests.
+func TestReconcile_ContextDone(t *testing.T) {
+	cases := []struct {
+		name      string
+		cancelCtx bool
+		wantErr   error
+	}{
+		{
+			name:    "surfaces_status_update_errors",
+			wantErr: errStatusPatch,
+		},
+		{
+			name:      "ignores_errors_once_context_is_done",
+			cancelCtx: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tc.cancelCtx {
+				cancel()
+			}
+
+			obj := &v1alpha1.TestClaim{ObjectMeta: metav1.ObjectMeta{Name: testFSMObjectName}}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(obj).
+				WithStatusSubresource(obj).
+				Build()
+
+			// mimic the API client, which fails all requests once their context is done
+			c := interceptor.NewClient(fakeClient, interceptor.Funcs{
+				SubResourcePatch: func(
+					ctx context.Context,
+					_ client.Client,
+					_ string,
+					_ client.Object,
+					_ client.Patch,
+					_ ...client.SubResourcePatchOption,
+				) error {
+					if err := ctx.Err(); err != nil {
+						return fmt.Errorf("client rate limiter Wait returned an error: %w", err)
+					}
+					return errStatusPatch
+				},
+			})
+
+			r := NewFSMReconciler[v1alpha1.TestClaim, *v1alpha1.TestClaim](
+				"test-fsm",
+				zaptest.NewLogger(t).Sugar(),
+				testApplicator(c),
+				scheme,
+				&fsmtypes.State[*v1alpha1.TestClaim]{
+					Name:      "initial",
+					Condition: api.Condition{Type: "Initial"},
+				},
+				nil,
+				nil,
+				metrics.MustMakeMetrics(scheme, prometheus.NewRegistry()),
+				fsmtypes.ReconcilerOptions[v1alpha1.TestClaim, *v1alpha1.TestClaim]{},
+			)
+
+			res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: testFSMObjectName}})
+
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("expected no error, got: %s", err)
+				}
+				if !res.IsZero() {
+					t.Errorf("expected an empty result, got: %+v", res)
+				}
+				return
+			}
+
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error running reconciler did not match expected\ngot: %v\nwant: %s", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a controller is shut down, it cancels the context of every in-progress `Reconcile()`. This fails every reconciler's outstanding API requests with an error like `"client rate limiter Wait returned an error: context canceled"`. These errors are expected and cannot be acted upon. We should ignore them instead of returning an error.

TODO: Test by pulling this into `achilles-release-controller` in staging and restarting the Pods a few times.