### PR TITLE
[claim] fix suspend semantics

### DIFF
--- a/pkg/fsm/internal/reconciler_claim.go
+++ b/pkg/fsm/internal/reconciler_claim.go
@@ -59,12 +59,16 @@ func (r *ClaimReconciler[T, Claimed, U, Claim]) Reconcile(ctx context.Context, r
 	}
 
 	claimed := Claimed(new(T))
+	claimedExists := false
 	if ref := claim.GetClaimedRef(); ref != nil {
 		// claim already bound, populate resource fields for future use
 		claimed.SetName(ref.Name)
-		if err := r.Client.Get(ctx, ref.ObjectKey(), claimed); err != nil && !k8serrors.IsNotFound(err) {
+		err := r.Client.Get(ctx, ref.ObjectKey(), claimed)
+		if err != nil && !k8serrors.IsNotFound(err) {
 			return ctrl.Result{}, fmt.Errorf("fetching %T %q: %w", claimed, ref.Name, err)
 		}
+		// NotFound means the claim is bound to a claimed object that no longer (or does not yet) exist
+		claimedExists = err == nil
 	} else {
 		// this is a fresh claim, generate a resource name.
 		//
@@ -89,8 +93,33 @@ func (r *ClaimReconciler[T, Claimed, U, Claim]) Reconcile(ctx context.Context, r
 		return ctrl.Result{}, fmt.Errorf("%w. got=%s, expected=%s", errClaimedRefMismatch, claimed.GetClaimRef(), claimRef)
 	}
 
-	// NOTE: only delete claimed object if claim is deleted and not suspended
-	if meta.WasDeleted(claim) && !meta.HasSuspendLabel(claim) {
+	// Handle suspension, propagate suspend label to the claimed object and skip all other logic.
+	// A suspended claim is therefore never bound, finalized, or deleted.
+	if meta.HasSuspendLabel(claim) {
+		// only propagate to an existing claimed object, suspension must not create one
+		if claimedExists {
+			// copy the suspended label
+			labels := map[string]string{}
+			if claimed.GetLabels() != nil {
+				labels = claimed.GetLabels()
+			}
+
+			labels[meta.SuspendKey] = "true"
+			claimed.SetLabels(labels)
+
+			if err := r.Client.Applicator.Apply(ctx, claimed, io.AsUpdate()); err != nil {
+				return ctrl.Result{}, fmt.Errorf("propagating suspend label to claimed: %w", err)
+			}
+		}
+
+		return ctrl.Result{}, nil
+	} else if meta.HasSuspendLabel(claimed) {
+		// remove suspend label from claimed object if not present on claim,
+		// persisted by the update applied further below
+		delete(claimed.GetLabels(), meta.SuspendKey)
+	}
+
+	if meta.WasDeleted(claim) {
 		if r.beforeDelete != nil {
 			if err := r.beforeDelete(claim, claimed); err != nil {
 				claim.SetConditions(api.Deleting().WithMessage(err.Error()))
@@ -101,14 +130,14 @@ func (r *ClaimReconciler[T, Claimed, U, Claim]) Reconcile(ctx context.Context, r
 			}
 		}
 
-		if meta.WasCreated(claimed) {
+		if claimedExists {
 			if err := r.Client.Delete(ctx, claimed, client.PropagationPolicy(metav1.DeletePropagationForeground)); k8serrors.IsNotFound(err) {
 				return ctrl.Result{}, nil
 			} else if err != nil {
 				return ctrl.Result{}, fmt.Errorf("deleting claimed: %w", err)
 			}
 		} else {
-			// remove finalizer, we're ready to delete
+			// remove finalizer, we're ready to delete the claim
 			if err := meta.RemoveFinalizer(ctx, r.Client.Client, claim, finalizer); err != nil && !k8serrors.IsNotFound(err) {
 				return ctrl.Result{}, fmt.Errorf("removing finalizer: %w", err)
 			}
@@ -133,20 +162,6 @@ func (r *ClaimReconciler[T, Claimed, U, Claim]) Reconcile(ctx context.Context, r
 	// ensure the state of the claimed resource
 	meta.SetRedditLabels(claimed, r.Name)
 	claimed.SetClaimRef(claimRef)
-
-	// NOTE: propagate suspend label to the claimed object
-	if meta.HasSuspendLabel(claim) {
-		// copy the suspended label
-		labels := map[string]string{}
-		if claimed.GetLabels() != nil {
-			labels = claimed.GetLabels()
-		}
-
-		labels[meta.SuspendKey] = "true"
-		claimed.SetLabels(labels)
-	} else if meta.HasSuspendLabel(claimed) {
-		delete(claimed.GetLabels(), meta.SuspendKey)
-	}
 
 	// update operation is needed to ensure suspend label is deleted from claimed object
 	if err := r.Client.Applicator.Apply(ctx, claimed, io.AsUpdate()); err != nil {

--- a/pkg/fsm/internal/reconciler_claim_test.go
+++ b/pkg/fsm/internal/reconciler_claim_test.go
@@ -55,7 +55,8 @@ func TestReconciler_Claim(t *testing.T) {
 			},
 			out: []client.Object{
 				apply(newTestClaim(), withFinalizer, withGeneratedClaimRef),
-				apply(&v1alpha1.TestClaimed{}, withGeneratedName, withRedditLabels, withClaimRef),
+				apply(&v1alpha1.TestClaimed{}, withGeneratedName, withRedditLabels, withClaimRef,
+					withCreatedTimestamp[*v1alpha1.TestClaimed]),
 			},
 		},
 		{
@@ -89,6 +90,72 @@ func TestReconciler_Claim(t *testing.T) {
 			},
 			missing: []client.Object{
 				newTestClaim(),
+			},
+		},
+		{
+			// a claim can be finalized before spec.claimedRef is persisted, so deleting it must still
+			// remove the finalizer rather than trying to delete a claimed object that was never created
+			name: "success/removes_finalizer_when_never_bound",
+			in: []client.Object{
+				apply(newTestClaim(), withFinalizer, withDeletedTimestamp[*v1alpha1.TestClaim]),
+			},
+			missing: []client.Object{
+				newTestClaim(),
+			},
+		},
+		{
+			name: "success/removes_suspend_label_from_claimed",
+			in: []client.Object{
+				apply(newTestClaim(), withFinalizer, withGeneratedClaimRef),
+				apply(&v1alpha1.TestClaimed{}, withGeneratedName, withClaimRef, withSuspendLabel[*v1alpha1.TestClaimed]),
+			},
+			out: []client.Object{
+				apply(newTestClaim(), withFinalizer, withGeneratedClaimRef),
+				apply(&v1alpha1.TestClaimed{}, withGeneratedName, withRedditLabels, withClaimRef),
+			},
+		},
+		{
+			// while suspended the reconciler propagates the suspend label and skips everything else,
+			// so the claimed object does not gain the reddit labels the full loop would have applied
+			name: "suspend/propagates_label_to_claimed",
+			in: []client.Object{
+				apply(newTestClaim(), withFinalizer, withGeneratedClaimRef, withSuspendLabel[*v1alpha1.TestClaim]),
+				apply(&v1alpha1.TestClaimed{}, withGeneratedName, withClaimRef, withCreatedTimestamp[*v1alpha1.TestClaimed]),
+			},
+			out: []client.Object{
+				apply(newTestClaim(), withFinalizer, withGeneratedClaimRef, withSuspendLabel[*v1alpha1.TestClaim]),
+				apply(&v1alpha1.TestClaimed{}, withGeneratedName, withClaimRef, withCreatedTimestamp[*v1alpha1.TestClaimed],
+					withSuspendLabel[*v1alpha1.TestClaimed]),
+			},
+		},
+		{
+			// a claim suspended before it ever bound must not be finalized or bound, and must not
+			// create a claimed object
+			name: "suspend/does_not_bind_fresh_claim",
+			in: []client.Object{
+				apply(newTestClaim(), withSuspendLabel[*v1alpha1.TestClaim]),
+			},
+			out: []client.Object{
+				apply(newTestClaim(), withSuspendLabel[*v1alpha1.TestClaim]),
+			},
+			missing: []client.Object{
+				apply(&v1alpha1.TestClaimed{}, withGeneratedName),
+			},
+		},
+		{
+			// deleting a suspended claim leaves it terminating: the claimed object is not deleted and
+			// the finalizer is not removed
+			name: "suspend/skips_delete",
+			in: []client.Object{
+				apply(newTestClaim(), withFinalizer, withGeneratedClaimRef, withSuspendLabel[*v1alpha1.TestClaim],
+					withDeletedTimestamp[*v1alpha1.TestClaim]),
+				apply(&v1alpha1.TestClaimed{}, withGeneratedName, withClaimRef, withCreatedTimestamp[*v1alpha1.TestClaimed]),
+			},
+			out: []client.Object{
+				apply(newTestClaim(), withFinalizer, withGeneratedClaimRef, withSuspendLabel[*v1alpha1.TestClaim],
+					withDeletedTimestamp[*v1alpha1.TestClaim]),
+				apply(&v1alpha1.TestClaimed{}, withGeneratedName, withClaimRef, withCreatedTimestamp[*v1alpha1.TestClaimed],
+					withSuspendLabel[*v1alpha1.TestClaimed]),
 			},
 		},
 		{
@@ -195,6 +262,15 @@ func withDeletedTimestamp[T client.Object](t T) {
 	t.SetDeletionTimestamp(&now)
 }
 
+func withSuspendLabel[T client.Object](t T) {
+	labels := t.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[meta.SuspendKey] = "true"
+	t.SetLabels(labels)
+}
+
 func withCreatedTimestamp[T client.Object](t T) {
 	t.SetCreationTimestamp(now)
 }
@@ -228,9 +304,16 @@ func testApplicator(c client.Client) *io.ClientApplicator {
 	}
 }
 
-func generateNameClientFilter(_ string, obj client.Object) error {
+// generateNameClientFilter emulates the apiserver's create behavior: a name is generated from
+// generateName and creationTimestamp is stamped. Stamping the timestamp matters because the reconciler
+// reserves a claimed name via a dry run create, so a claimed object that does not exist still comes
+// back looking created.
+func generateNameClientFilter(event string, obj client.Object) error {
 	if gn := obj.GetGenerateName(); gn != "" {
 		obj.SetName(gn + "abcde")
+	}
+	if createdAt := obj.GetCreationTimestamp(); event == "create" && createdAt.IsZero() {
+		obj.SetCreationTimestamp(now)
 	}
 	return nil
 }

--- a/pkg/fsm/internal/test/claim/claim_controller_test.go
+++ b/pkg/fsm/internal/test/claim/claim_controller_test.go
@@ -1,6 +1,8 @@
 package claim
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -146,6 +148,51 @@ var _ = Describe("Claim Controller", Ordered, func() {
 			Eventually(func(g Gomega) {
 				g.Expect(c.Get(ctx, claim.Spec.ClaimedRef.ObjectKey(), claimed)).ToNot(HaveOccurred())
 				g.Expect(claimed.DeletionTimestamp).ToNot(BeNil())
+			}).Should(Succeed())
+		})
+	})
+
+	It("should not bind a claim that is suspended before it binds", func() {
+		suspendedClaim := &v1alpha1.TestClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-claim-suspended",
+				Namespace: "default",
+				Labels: map[string]string{
+					"infrared.reddit.com/suspend": "true",
+				},
+			},
+			Spec: v1alpha1.TestClaimSpec{
+				TestField: "test-field",
+			},
+		}
+		Expect(c.Create(ctx, suspendedClaim)).To(Succeed())
+
+		By("leaving the claim unbound, unfinalized, and without a claimed object", func() {
+			Consistently(func(g Gomega) {
+				actualClaim := &v1alpha1.TestClaim{}
+				g.Expect(c.Get(ctx, client.ObjectKeyFromObject(suspendedClaim), actualClaim)).ToNot(HaveOccurred())
+				g.Expect(actualClaim.Spec.ClaimedRef).To(BeNil())
+				g.Expect(actualClaim.GetFinalizers()).ToNot(ContainElement("cloud.infrared.reddit.com/claim"))
+			}, 2*time.Second, 200*time.Millisecond).Should(Succeed())
+		})
+
+		By("binding once the suspend label is removed", func() {
+			Eventually(func(g Gomega) {
+				actualClaim := &v1alpha1.TestClaim{}
+				g.Expect(c.Get(ctx, client.ObjectKeyFromObject(suspendedClaim), actualClaim)).ToNot(HaveOccurred())
+				delete(actualClaim.Labels, "infrared.reddit.com/suspend")
+				g.Expect(c.Update(ctx, actualClaim)).ToNot(HaveOccurred())
+			}).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				actualClaim := &v1alpha1.TestClaim{}
+				g.Expect(c.Get(ctx, client.ObjectKeyFromObject(suspendedClaim), actualClaim)).ToNot(HaveOccurred())
+				g.Expect(actualClaim.Spec.ClaimedRef).ToNot(BeNil())
+				g.Expect(actualClaim.GetFinalizers()).To(ContainElement("cloud.infrared.reddit.com/claim"))
+
+				claimed := &v1alpha1.TestClaimed{}
+				g.Expect(c.Get(ctx, actualClaim.Spec.ClaimedRef.ObjectKey(), claimed)).ToNot(HaveOccurred())
+				g.Expect(meta.HasSuspendLabel(claimed)).To(BeFalse())
 			}).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
## Make `infrared.reddit.com/suspend` actually suspend the claim reconciler

Suspend was only ever consulted on the `ClaimReconciler`'s delete branch, so everything else ran
while a claim was suspended: the claim was still bound, the `cloud.infrared.reddit.com/claim`
finalizer was still added, the claimed object was still created, and status was still updated. **Most
visibly, stripping the finalizer off a suspended claim by hand didn't stick, since the next
reconcile re-added it.**

Suspend is now an early return. While a claim is suspended the reconciler propagates the suspend
label to an already-existing claimed object and does nothing else.

### Behavior changes

- A suspended claim is not bound (`spec.claimedRef`), not finalized, and its status is not updated.
- A claim suspended before it ever binds stays unbound with no claimed object, and binds normally
  once resumed.
- Unchanged: deleting a suspended claim still leaves it in Terminating, since delete is skipped and
  the finalizer is therefore not removed.

This applies to every controller built with `ClaimBuilder`; no caller changes are needed.

### Also fixes: `meta.WasCreated(claimed)` is not a valid existence check here

For an unbound claim the reconciler reserves a name via `Create(..., client.DryRunAll)`, and the
apiserver's dry-run response populates `creationTimestamp` — so a claimed object that does not exist
looks created. Existence is now tracked from whether the `Get` returned `NotFound`, and both the
suspend and delete branches use that. This fixes two bugs:

- Suspend would create an orphan claimed object with a nil `spec.claimRef`, panicking the claim
  controller, because the claimed watch's map function dereferences `GetClaimRef()` unconditionally.
- A claim deleted after being finalized but before `spec.claimedRef` was persisted would wedge
  forever: the reconciler tried to delete a claimed object that was never created, got `NotFound`,
  returned early, and never removed the finalizer.

### Tests

New table cases in `reconciler_claim_test.go`: `suspend/propagates_label_to_claimed`,
`suspend/does_not_bind_fresh_claim`, `suspend/skips_delete`,
`success/removes_suspend_label_from_claimed`, and `success/removes_finalizer_when_never_bound`.
`generateNameClientFilter` now stamps `creationTimestamp` on create so the fake client matches the
apiserver's dry-run response — without that, the orphan-creation bug is invisible at the unit level.

New envtest spec: "should not bind a claim that is suspended before it binds". The existing
"should handle suspend label is set" spec is unchanged and still passes.

### Docs

The `heel` runbook's "Claim Resources" section documented the old semantics ("the entire reconcile
loop is run... the only action that is skipped is handling deletes"). [Companion PR](https://github.snooguts.net/reddit/achilles-docs/pull/455) in
`achilles-docs` rewrites it and keeps the old behavior in a callout for older Achilles versions.