### PR TITLE
Don't call client.ObjectKeyFromObject on nil object

### DIFF
--- a/pkg/fsm/io/outputs.go
+++ b/pkg/fsm/io/outputs.go
@@ -72,7 +72,7 @@ func applyManagedResourceRefs[T any, Obj apitypes.FSMResource[T]](
 		// verify that managed object exists, emit warning if not
 		managedObj, err := meta.NewObjectForGVK(scheme, ref.GroupVersionKind())
 		if err != nil {
-			return fmt.Errorf("constructing new %T %s: %w", managedObj, client.ObjectKeyFromObject(managedObj), err)
+			return fmt.Errorf("constructing managed resource %s: %w", ref.GroupVersionKind(), err)
 		}
 		managedObj.SetName(ref.Name)
 		managedObj.SetNamespace(ref.Namespace)

--- a/pkg/fsm/types/transitions.go
+++ b/pkg/fsm/types/transitions.go
@@ -325,7 +325,7 @@ func readManagedResources(
 		res := res // pike
 		managedObj, err := meta.NewObjectForGVK(scheme, res.GroupVersionKind())
 		if err != nil {
-			return nil, fmt.Errorf("constructing new %T %s: %w", managedObj, client.ObjectKeyFromObject(managedObj), err)
+			return nil, fmt.Errorf("constructing managed resource %s: %w", res.GroupVersionKind(), err)
 		}
 
 		if err := c.Get(ctx, res.ObjectKey(), managedObj); err != nil {

--- a/pkg/fsm/types/transitions_test.go
+++ b/pkg/fsm/types/transitions_test.go
@@ -391,3 +391,28 @@ func Test_ErrorResultf(t *testing.T) {
 		})
 	}
 }
+
+func TestReadManagedResources_UnknownGVKReturnsError(t *testing.T) {
+	scheme, err := intscheme.NewScheme()
+	assert.NoError(t, err)
+
+	parent := &testv1alpha1.TestClaimed{
+		Status: testv1alpha1.TestClaimedStatus{
+			Resources: []api.TypedObjectRef{{
+				Group:   "example.com",
+				Version: "v1",
+				Kind:    "Unregistered",
+				Name:    "child",
+			}},
+		},
+	}
+
+	_, err = readManagedResources(
+		context.Background(),
+		fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme,
+		parent,
+	)
+
+	assert.ErrorContains(t, err, "constructing managed resource example.com/v1, Kind=Unregistered")
+}


### PR DESCRIPTION
`managedObj` is nil when it hits this path so this always panics.

Avoid the panic by not using `managedObj` in this branch.


```
goroutine 1427 [running]:

k8s.io/apimachinery/pkg/util/runtime.logPanic({0x29bcf18, 0xc028b46900}, {0x233dbe0, 0x3cbd4f0})
	/go/pkg/mod/k8s.io/apimachinery@v0.34.2/pkg/util/runtime/runtime.go:132 +0xbc

sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:108 +0x112

panic({0x233dbe0?, 0x3cbd4f0?})
	/usr/local/go/src/runtime/panic.go:792 +0x132

sigs.k8s.io/controller-runtime/pkg/client.ObjectKeyFromObject({0x0, 0x0})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/client/interfaces.go:36 +0x18

github.com/reddit/achilles-sdk/pkg/fsm/io.applyManagedResourceRefs[...]({0x29bcf18, 0xc028b46900}, 0xc00024aab8, 0xc000809e60, 0xc0003b8ee0, 0xc001b6a000, 0xc001999060)
	/go/pkg/mod/github.com/reddit/achilles-sdk@v0.13.13/pkg/fsm/io/outputs.go:75 +0x66b

github.com/reddit/achilles-sdk/pkg/fsm/io.ApplyOutputSet[...]({0x29bcf18, 0xc028b46900}, 0xc00024aab8, 0xc000809e60, 0xc0003b8ee0, 0xc001b6a000, 0xc001999060)
	/go/pkg/mod/github.com/reddit/achilles-sdk@v0.13.13/pkg/fsm/io/outputs.go:45 +0x2d7

github.com/reddit/achilles-sdk/pkg/fsm/internal.(*fsmReconciler[...]).applyOutputs(0x29df620, {0x29bcf18, 0xc028b46900}, 0xc02c37a610, 0xc001b6a000, 0xc001999060)
	/go/pkg/mod/github.com/reddit/achilles-sdk@v0.13.13/pkg/fsm/internal/reconciler.go:339 +0x209

github.com/reddit/achilles-sdk/pkg/fsm/internal.(*fsmReconciler[...]).reconcile(0x29df620, {0x29bcf18, 0xc028b46900}, {{{0xc02af54030, 0x5}, {0xc026f7f008, 0x12}}}, 0xc02c37a610)
	/go/pkg/mod/github.com/reddit/achilles-sdk@v0.13.13/pkg/fsm/internal/reconciler.go:292 +0xf9b

github.com/reddit/achilles-sdk/pkg/fsm/internal.(*fsmReconciler[...]).Reconcile(0x29df620, {0x29bcf18, 0xc028b46900}, {{{0xc02af54030, 0x5}, {0xc026f7f008, 0x12}}})
	/go/pkg/mod/github.com/reddit/achilles-sdk@v0.13.13/pkg/fsm/internal/reconciler.go:122 +0x388

sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0xc028b46870?, {0x29bcf18?, 0xc028b46900?}, {{{0xc02af54030?, 0x0?}, {0xc026f7f008?, 0x0?}}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:119 +0xbf

sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x29e5820, {0x29bcf50, 0xc00031ea50}, {{{0xc02af54030, 0x5}, {0xc026f7f008, 0x12}}}, 0x0)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:340 +0x3ad

sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x29e5820, {0x29bcf50, 0xc00031ea50})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:300 +0x21b

sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:202 +0x85

created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2 in goroutine 184
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:198 +0x28f
```