### PR TITLE
Support consumers on controller-runtime v0.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,12 @@ jobs:
       matrix:
         go-version:
           - "1.24"
+        controller-runtime:
+          # "pinned" tests against the versions in go.mod; explicit versions
+          # verify compatibility with newer controller-runtime releases that
+          # consumers may resolve to via MVS.
+          - pinned
+          - v0.22.5
 
     container:
       image: golang:${{ matrix.go-version }}
@@ -27,6 +33,7 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Generate
+        if: matrix.controller-runtime == 'pinned'
         run: |
           # needed for running `tar -xJv` for installing shellcheck
           apt-get update
@@ -42,6 +49,12 @@ jobs:
           git status
           git diff
           test -z "$(git status --porcelain)"
+
+      - name: Upgrade controller-runtime
+        if: matrix.controller-runtime != 'pinned'
+        run: |
+          go get sigs.k8s.io/controller-runtime@${{ matrix.controller-runtime }}
+          go mod tidy
 
       - name: Test
         run: make test

--- a/pkg/fsm/internal/test/core/test_fsm_reconciler.go
+++ b/pkg/fsm/internal/test/core/test_fsm_reconciler.go
@@ -112,7 +112,7 @@ func BuildReconciler(
 	metrics *metrics.Metrics,
 	disableAutoCreate *atomic.Bool,
 ) reconcile.TypedReconciler[ctrl.Request] {
-	return fsmBuilder(log, mgr, c, disableAutoCreate).Reconciler(log, mgr.GetScheme(), c, metrics)
+	return fsmBuilder(log, mgr, c, disableAutoCreate).Reconciler(log, mgr.GetScheme(), c.Client, metrics)
 }
 
 func SetupController(

--- a/pkg/fsm/types/transitions.go
+++ b/pkg/fsm/types/transitions.go
@@ -323,7 +323,8 @@ func readManagedResources(
 
 	for _, res := range parent.GetManagedResources() {
 		res := res // pike
-		managedObj, err := meta.NewObjectForGVK(scheme, res.GroupVersionKind())
+		gvk := res.GroupVersionKind()
+		managedObj, err := meta.NewObjectForGVK(scheme, gvk)
 		if err != nil {
 			return nil, fmt.Errorf("constructing new %T %s: %w", managedObj, client.ObjectKeyFromObject(managedObj), err)
 		}
@@ -335,6 +336,10 @@ func readManagedResources(
 			}
 			return nil, fmt.Errorf("getting managed resource %T %s: %w", managedObj, client.ObjectKeyFromObject(managedObj), err)
 		} else {
+			// Clients strip TypeMeta from typed objects on Get, so restore it for callers
+			// that rely on the object's GVK.
+			// See https://github.com/kubernetes-sigs/controller-runtime/issues/1517
+			managedObj.GetObjectKind().SetGroupVersionKind(gvk)
 			managedResources = append(managedResources, managedObj)
 		}
 	}

--- a/pkg/fsm/types/transitions_test.go
+++ b/pkg/fsm/types/transitions_test.go
@@ -100,7 +100,7 @@ func Test_GetUnreadyResources(t *testing.T) {
 		// Create a new instance of the TransitionWhenReady function
 		unreadyResources, err := GetUnreadyResources(
 			ctx,
-			c,
+			c.Client,
 			scheme,
 			log,
 			tc.parent,
@@ -234,7 +234,7 @@ func Test_TransitionWhenReady(t *testing.T) {
 
 		// Create a new instance of the TransitionWhenReady function
 		actualNextState, actualResult := TransitionWhenReady[*testv1alpha1.TestClaimed](
-			c,
+			c.Client,
 			scheme,
 			log,
 			successState,

--- a/pkg/kubeconfig/secret_test.go
+++ b/pkg/kubeconfig/secret_test.go
@@ -74,6 +74,13 @@ var _ = Describe("kubeconfig secret", func() {
 		actualCfg, err := actualClientCfg.RawConfig()
 		Expect(err).ToNot(HaveOccurred())
 
+		// Deserialization produces an empty Preferences.Extensions map on client-go
+		// v0.33 and earlier but leaves it nil on v0.34+; normalize so the assertion
+		// holds on both.
+		if actualCfg.Preferences.Extensions == nil {
+			actualCfg.Preferences.Extensions = map[string]runtime.Object{}
+		}
+
 		Expect(&actualCfg).To(Equal(cfg))
 	})
 


### PR DESCRIPTION
## 💸 TL;DR

Makes the SDK's own build and test suite pass against controller-runtime v0.22 (Kubernetes 1.34 libraries), and adds a CI matrix job so v0.22 compatibility stays verified. The go.mod pins are unchanged — v0.21 remains the minimum, and the full suite still passes there.

The v0.13.13 release notes anticipated consumers resolving to controller-runtime v0.22 via MVS (`*io.ClientApplicator` no longer satisfying `client.Client`). The library code already handles that, but a few of the SDK's own test files still passed `*io.ClientApplicator` as a `client.Client`, and two tests depended on behaviors that changed in the newer libraries:

- `transitions_test.go` / `test_fsm_reconciler.go`: pass the embedded `.Client` instead of the applicator (compiles under both versions).
- `readManagedResources` now restores the GVK on fetched objects; controller-runtime v0.22's fake client strips `TypeMeta` on `Get` (matching real clients — see kubernetes-sigs/controller-runtime#1517), which broke `Test_GetUnreadyResources`. Restoring it is a no-op under v0.21.
- `secret_test.go`: client-go v0.34+ leaves `Preferences.Extensions` nil after deserialization where earlier versions produced an empty map; the assertion now normalizes.

This is a smaller, dual-version alternative to the v0.23-targeting parts of #107 — v0.23 support (generic webhook builders, `SubResourceWriter.Apply` in `pkg/test`) is intentionally out of scope since it can't be dual-compiled with v0.21.

## 🧪 Testing Steps / Validation

- `make test` passes on the pinned go.mod versions (controller-runtime v0.21).
- After `go get sigs.k8s.io/controller-runtime@v0.22.5 && go mod tidy`, everything builds and the previously-failing packages (`pkg/fsm/...`, `pkg/io`, `pkg/kubeconfig`, `pkg/test`) pass.
- The new CI job runs the same upgrade-then-test flow on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)